### PR TITLE
compile from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,16 @@ const pil = await compile(Fr, "pil/main.pil", null,  pilConfig);
 - **verbose**: source code ignored inside a namespace was shown (first 3 lines).
 - **color**: verbose source code was shown with other color.
 - **disableUnusedError**: ignore error when found an unused expression.
+- **compileFromString**: use to indicate to compiler that parameter fileName contains directly code of pil, to avoid to use a temporal directory on dynamic pil generation.
+- **includePaths**: an array of paths used to find includes.
+- **includePathFirst**: a boolean value (true), to force to find first on include path and after on current pil directory. Default: false
 ### Command Line
 
-In command line compilation, could specify config with json file and using option -P or --config.
+In command line compilation:
+- config with json file and using option -P or --config.
+- define include paths with option -I or --include, and paths separated by comma.
+- define includePathFirst with option -f.
+
 
 ## License
 

--- a/src/pil.js
+++ b/src/pil.js
@@ -16,7 +16,7 @@ const argv = require("yargs")
     .alias("P", "config")
     .alias("v", "verbose")
     .alias("I", "include")
-    .alias("f", "includePathsFirst")
+    .alias("f", "includePathFirst")
     .argv;
 
 async function run() {
@@ -53,7 +53,7 @@ async function run() {
         config.includePaths = argv.include.split(',');
     }
 
-    if (argv.includePathsFirst) {
+    if (argv.includePathFirst) {
         config.includePathFirst = true;
     }
     const out = await compile(F, fullFileName, null, config);

--- a/src/pil.js
+++ b/src/pil.js
@@ -15,6 +15,8 @@ const argv = require("yargs")
     .alias("c", "ccodegeneration")
     .alias("P", "config")
     .alias("v", "verbose")
+    .alias("I", "include")
+    .alias("f", "includePathsFirst")
     .argv;
 
 async function run() {
@@ -47,6 +49,13 @@ async function run() {
 
     const F = new ffjavascript.F1Field((1n<<64n)-(1n<<32n)+1n );
 
+    if (argv.include) {
+        config.includePaths = argv.include.split(',');
+    }
+
+    if (argv.includePathsFirst) {
+        config.includePathFirst = true;
+    }
     const out = await compile(F, fullFileName, null, config);
 
     console.log("Input Pol Commitmets: " + out.nCommitments);

--- a/test/compileFromString.js
+++ b/test/compileFromString.js
@@ -1,0 +1,71 @@
+const chai = require("chai");
+const { F1Field } = require("ffjavascript");
+const fs = require("fs");
+const path = require("path");
+const assert = chai.assert;
+var tmp = require('tmp-promise');
+const { compile, newConstantPolsArray, newCommitPolsArray } = require("..");
+
+
+describe("CompileFromString", async function () {
+    this.timeout(10000000);
+
+    it("It should compile from string", async () => {
+        const F = new F1Field(0xffffffff00000001n);
+
+        const pil = await compile(F,
+            `namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             pol constant BYTE;
+            `, null,
+            { compileFromString: true });
+
+        assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE']);
+        return false;
+    });
+    it("It should compile from string with include without includePaths", async () => {
+        const F = new F1Field(0xffffffff00000001n);
+
+        const pil = await compile(F,
+            `namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             pol constant BYTE;
+             include "test/examples/path1/includePath.pil"
+             `, null,
+            { compileFromString: true });
+
+        assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE', 'IncludePath.path1const']);
+        return false;
+    });
+    it("It should compile from string with include and includePaths", async () => {
+        const F = new F1Field(0xffffffff00000001n);
+
+        const pil = await compile(F,
+            `namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             pol constant BYTE;
+             include "includePath.pil"
+             `, null,
+            { compileFromString: true,
+              includePaths: ['test/examples/path2']});
+
+        assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE', 'IncludePath.path2const']);
+        return false;
+    });
+    it("It should compile from file with regular include", async () => {
+        const F = new F1Field(0xffffffff00000001n);
+
+        const pil = await compile(F, 'test/examples/mainIncludePath1.pil');
+        assert.containsAllKeys(pil.references, ['MainIncludePath1.L1', 'MainIncludePath1.BYTE', 'IncludePath.path1const']);
+        return false;
+    });
+    it("It should compile from file with includePaths", async () => {
+        const F = new F1Field(0xffffffff00000001n);
+
+        const pil = await compile(F,'test/examples/mainIncludePath2.pil', null,
+            { includePaths: ['test/examples/path2']});
+
+        assert.containsAllKeys(pil.references, ['MainIncludePath2.L1', 'MainIncludePath2.BYTE', 'IncludePath.path2const']);
+        return false;
+    });
+});

--- a/test/compileFromString.js
+++ b/test/compileFromString.js
@@ -1,17 +1,20 @@
 const chai = require("chai");
+const { exec } = require("child_process");
 const { F1Field } = require("ffjavascript");
 const fs = require("fs");
 const path = require("path");
 const assert = chai.assert;
+const { execSync } = require('child_process');
 var tmp = require('tmp-promise');
 const { compile, newConstantPolsArray, newCommitPolsArray } = require("..");
 
 
-describe("CompileFromString", async function () {
+describe("CompileFromString (string compilation - library)", async function () {
+
+    const F = new F1Field(0xffffffff00000001n);
     this.timeout(10000000);
 
     it("It should compile from string", async () => {
-        const F = new F1Field(0xffffffff00000001n);
 
         const pil = await compile(F,
             `namespace Global(%N);
@@ -21,10 +24,9 @@ describe("CompileFromString", async function () {
             { compileFromString: true });
 
         assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE']);
-        return false;
     });
+
     it("It should compile from string with include without includePaths", async () => {
-        const F = new F1Field(0xffffffff00000001n);
 
         const pil = await compile(F,
             `namespace Global(%N);
@@ -35,10 +37,9 @@ describe("CompileFromString", async function () {
             { compileFromString: true });
 
         assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE', 'IncludePath.path1const']);
-        return false;
     });
+
     it("It should compile from string with include and includePaths", async () => {
-        const F = new F1Field(0xffffffff00000001n);
 
         const pil = await compile(F,
             `namespace Global(%N);
@@ -50,22 +51,74 @@ describe("CompileFromString", async function () {
               includePaths: ['test/examples/path2']});
 
         assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE', 'IncludePath.path2const']);
-        return false;
     });
-    it("It should compile from file with regular include", async () => {
-        const F = new F1Field(0xffffffff00000001n);
+});
+
+describe("CompileFromString (file compilation - library)", async function () {
+
+    const F = new F1Field(0xffffffff00000001n);
+    this.timeout(10000000);
+
+    it("It should compile from file (library) with regular include", async () => {
 
         const pil = await compile(F, 'test/examples/mainIncludePath1.pil');
         assert.containsAllKeys(pil.references, ['MainIncludePath1.L1', 'MainIncludePath1.BYTE', 'IncludePath.path1const']);
-        return false;
     });
-    it("It should compile from file with includePaths", async () => {
-        const F = new F1Field(0xffffffff00000001n);
+
+    it("It should compile from file (library) with regular include with includePathFirst=true", async () => {
+
+        const pil = await compile(F, 'test/examples/mainIncludePath1.pil', null, {includePathFirst: true});
+        assert.containsAllKeys(pil.references, ['MainIncludePath1.L1', 'MainIncludePath1.BYTE', 'IncludePath.path1const']);
+    });
+
+    it("It should compile from file (library) with includePaths", async () => {
 
         const pil = await compile(F,'test/examples/mainIncludePath2.pil', null,
             { includePaths: ['test/examples/path2']});
 
-        assert.containsAllKeys(pil.references, ['MainIncludePath2.L1', 'MainIncludePath2.BYTE', 'IncludePath.path2const']);
-        return false;
+        assert.containsAllKeys(pil.references, ['MainIncludePath2.L1', 'MainIncludePath2.BYTE', 'IncludePath.pathconst']);
+    });
+
+    it("It should compile from file (library) with includePaths with includePathFirst=true", async () => {
+
+        const pil = await compile(F,'test/examples/mainIncludePath2.pil', null,
+            { includePaths: ['test/examples/path1'], includePathFirst: true});
+
+        assert.containsAllKeys(pil.references, ['MainIncludePath2.L1', 'MainIncludePath2.BYTE', 'IncludePath.path1const']);
+    });
+});
+
+describe("CompileFromString (file compilation - cmdline)", async function () {
+
+    const F = new F1Field(0xffffffff00000001n);
+    const output = '/tmp/CompileFromStringTest2.pil.json';
+    this.timeout(10000000);
+
+    it("It should compile from file (cmdline) with regular include", async () => {
+        execSync(`src/pil.js test/examples/mainIncludePath1.pil -o ${output}`);
+        const pil = JSON.parse(fs.readFileSync(output));
+        assert.containsAllKeys(pil.references, ['MainIncludePath1.L1', 'MainIncludePath1.BYTE', 'IncludePath.path1const']);
+    });
+
+    it("It should compile from file (cmdline) with regular include with includePathFirst=true", async () => {
+        execSync(`src/pil.js test/examples/mainIncludePath1.pil -f -o ${output}`);
+        const pil = JSON.parse(fs.readFileSync(output));
+        assert.containsAllKeys(pil.references, ['MainIncludePath1.L1', 'MainIncludePath1.BYTE', 'IncludePath.path1const']);
+    });
+
+    it("It should compile from file (cmdline) with includePaths", async () => {
+        execSync(`src/pil.js test/examples/mainIncludePath2.pil -I test/examples/path2 -o ${output}`);
+        const pil = JSON.parse(fs.readFileSync(output));
+        assert.containsAllKeys(pil.references, ['MainIncludePath2.L1', 'MainIncludePath2.BYTE', 'IncludePath.pathconst']);
+    });
+
+    it("It should compile from file (cmdline) with includePaths with includePathFirst=true", async () => {
+        execSync(`src/pil.js test/examples/mainIncludePath2.pil -f -I test/examples/path1 -o ${output}`);
+        const pil = JSON.parse(fs.readFileSync(output));
+        assert.containsAllKeys(pil.references, ['MainIncludePath2.L1', 'MainIncludePath2.BYTE', 'IncludePath.path1const']);
+    });
+
+    beforeEach(() => {
+        if (fs.existsSync(output, fs.constants.W_OK | fs.constants.R_OK)) fs.unlinkSync(output);
     });
 });

--- a/test/examples/includePath.pil
+++ b/test/examples/includePath.pil
@@ -1,0 +1,2 @@
+namespace IncludePath(2**16);
+    pol constant pathconst;

--- a/test/examples/mainIncludePath1.pil
+++ b/test/examples/mainIncludePath1.pil
@@ -1,0 +1,5 @@
+namespace MainIncludePath1(%N);
+    include "path1/includePath.pil";
+
+    pol constant L1;    // 1, 0, 0, 0, 0
+    pol constant BYTE

--- a/test/examples/mainIncludePath2.pil
+++ b/test/examples/mainIncludePath2.pil
@@ -1,0 +1,5 @@
+namespace MainIncludePath2(%N);
+    include "includePath.pil";
+
+    pol constant L1;    // 1, 0, 0, 0, 0
+    pol constant BYTE

--- a/test/examples/path1/includePath.pil
+++ b/test/examples/path1/includePath.pil
@@ -1,0 +1,2 @@
+namespace IncludePath(2**16);
+    pol constant path1const;

--- a/test/examples/path2/includePath.pil
+++ b/test/examples/path2/includePath.pil
@@ -1,0 +1,2 @@
+namespace IncludePath(2**16);
+    pol constant path2const;


### PR DESCRIPTION
Features:
- adding compileFromString config flag to specify on fileName parameter code of pil.
- adding includePaths config option to specify a list of directories where search includes.
- adding includePathFirst config flag to specify that first must check paths.

Created mocha called compileFromString to test all variants of these feature.