### PR TITLE
fix a bug when permutation check fails

### DIFF
--- a/src/pil_verifier.js
+++ b/src/pil_verifier.js
@@ -202,6 +202,7 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
             }
         }
 
+        let foundErrors = false;
         for (let j=0; j<N; j++) {
             if ((pi.selF==null) || (!F.isZero(pols.exps[pi.selF].v_n[j]))) {
                 const vals = []
@@ -213,14 +214,17 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
                 if (!t[v]) {
                     res.push(`${pi.fileName}:${pi.line}:  permutation not `+(found === 0 ? 'enought ':'')+`found w=${j} values: ${v}`);
                     console.log(res[res.length-1]);
-                    if (!config.continueOnError) j=N;  // Do not continue checking
+                    if (!config.continueOnError) {
+                        j=N;  // Do not continue checking
+                        foundErrors = true;
+                    }
                 }
                 else {
                     t[v] -= 1;
                 }
             }
         }
-        if (config.continueOnError) {
+        if (!foundErrors || config.continueOnError) {
             for (const v in t) {
                 if (t[v] === 0) continue;
                 res.push(`${pi.fileName}:${pi.line}:  permutation failed. Remaining ${t[v]} values: ${v}`);

--- a/src/pil_verifier.js
+++ b/src/pil_verifier.js
@@ -202,7 +202,7 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
             }
         }
 
-        let foundErrors = false;
+        let showRemainingErrors = true;
         for (let j=0; j<N; j++) {
             if ((pi.selF==null) || (!F.isZero(pols.exps[pi.selF].v_n[j]))) {
                 const vals = []
@@ -216,7 +216,7 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
                     console.log(res[res.length-1]);
                     if (!config.continueOnError) {
                         j=N;  // Do not continue checking
-                        foundErrors = true;
+                        showRemainingErrors = false;
                     }
                 }
                 else {
@@ -224,7 +224,7 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
                 }
             }
         }
-        if (!foundErrors || config.continueOnError) {
+        if (showRemainingErrors) {
             for (const v in t) {
                 if (t[v] === 0) continue;
                 res.push(`${pi.fileName}:${pi.line}:  permutation failed. Remaining ${t[v]} values: ${v}`);

--- a/test/permutationCheck.js
+++ b/test/permutationCheck.js
@@ -42,7 +42,7 @@ describe("Permutation Check Verification", async function () {
             cmPols.PermutationExample.a2[i] = BigInt(a2[i]);
         }
         const res = await verifyPil(F, pil, cmPols, constPols);
-        assert.equal(res, "(string):7:  permutation failed. Remaining 1 values: 1:4");
+        assert.equal(res, "(string):7:  permutation failed. Remaining 1 values: 4");
     });
 
 });

--- a/test/permutationCheck.js
+++ b/test/permutationCheck.js
@@ -1,0 +1,48 @@
+const chai = require("chai");
+const { exec } = require("child_process");
+const { F1Field } = require("ffjavascript");
+const fs = require("fs");
+const path = require("path");
+const assert = chai.assert;
+const { execSync } = require('child_process');
+var tmp = require('tmp-promise');
+const { compile, verifyPil, newConstantPolsArray, newCommitPolsArray } = require("..");
+
+
+describe("Permutation Check Verification", async function () {
+
+    const F = new F1Field(0xffffffff00000001n);
+    this.timeout(10000000);
+
+    it("ZKEV-15 Test", async () => {
+
+        const pil = await compile(F,
+            `constant %N = 4;
+             namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             namespace PermutationExample(%N);
+             pol constant b1,b2;
+             pol commit a1, a2;
+             b1{a1} is b2{a2};
+            `, null,
+            { compileFromString: true });
+
+        let constPols = newConstantPolsArray(pil);
+        let cmPols = newCommitPolsArray(pil);
+        const L1 = [1,0,0,0];
+        const b1 = [1,1,1,0];
+        const b2 = [1,1,1,1];
+        const a1 = [1,2,3,4];
+        const a2 = [4,3,2,1];
+        for (i = 0; i<4; ++i) {
+            constPols.Global.L1[i] = BigInt(L1[i]);
+            constPols.PermutationExample.b1[i] = BigInt(b1[i]);
+            constPols.PermutationExample.b2[i] = BigInt(b2[i]);
+            cmPols.PermutationExample.a1[i] = BigInt(a1[i]);
+            cmPols.PermutationExample.a2[i] = BigInt(a2[i]);
+        }
+        const res = await verifyPil(F, pil, cmPols, constPols);
+        assert.equal(res, "(string):7:  permutation failed. Remaining 1 values: 1:4");
+    });
+
+});


### PR DESCRIPTION
When permutation check fails because there are remaining values, if option flag continueOnError not active the error wasn't reporter, and pil verify return pass. ZKEV-15