### PR TITLE
fix non binary selectors

### DIFF
--- a/src/pil_verifier.js
+++ b/src/pil_verifier.js
@@ -132,22 +132,25 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
 
         let t = {};
         for (let j=0; j<N; j++) {
-            if ((pi.selT==null) || (!F.isZero(pols.exps[pi.selT].v_n[j]))) {
+            const selTValue = pi.selT == null ? F.zero : pols.exps[pi.selT].v_n[j];
+            if (!F.isZero(selTValue)) {
                 const vals = []
                 for (let k=0; k<pi.t.length; k++) {
                     vals.push(F.toString(pols.exps[pi.t[k]].v_n[j]));
                 }
-                t[vals.join(",")] = true;
+                const v = selTValue + ':' + vals.join(",");
+                t[v] = true;
             }
         }
 
         for (let j=0; j<N; j++) {
-            if ((pi.selF==null) || (!F.isZero(pols.exps[pi.selF].v_n[j]))) {
+            const selFValue = pi.selF == null ? F.zero : pols.exps[pi.selF].v_n[j];
+            if (!F.isZero(selFValue)) {
                 const vals = []
                 for (let k=0; k<pi.f.length; k++) {
                     vals.push(F.toString(pols.exps[pi.f[k]].v_n[j]));
                 }
-                const v = vals.join(",");
+                const v = selFValue + ':' + vals.join(",");
                 if (!t[v]) {
                     res.push(`${pil.plookupIdentities[i].fileName}:${pil.plookupIdentities[i].line}:  plookup not found w=${j} values: ${v}`);
                     console.log(res[res.length-1]);
@@ -192,24 +195,26 @@ module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}
 
         let t = {};
         for (let j=0; j<N; j++) {
-            if ((pi.selT==null) || (!F.isZero(pols.exps[pi.selT].v_n[j]))) {
+            const selTValue = pi.selT == null ? F.zero : pols.exps[pi.selT].v_n[j];
+            if (!F.isZero(selTValue)) {
                 const vals = []
                 for (let k=0; k<pi.t.length; k++) {
                     vals.push(F.toString(pols.exps[pi.t[k]].v_n[j]));
                 }
-                const v = vals.join(",");
+                const v = selTValue + ':' + vals.join(",");
                 t[v] = (t[v] || 0) + 1;
             }
         }
 
         let showRemainingErrors = true;
         for (let j=0; j<N; j++) {
-            if ((pi.selF==null) || (!F.isZero(pols.exps[pi.selF].v_n[j]))) {
+            const selFValue = pi.selF == null ? F.zero : pols.exps[pi.selF].v_n[j];
+            if (!F.isZero(selFValue)) {
                 const vals = []
                 for (let k=0; k<pi.f.length; k++) {
                     vals.push(F.toString(pols.exps[pi.f[k]].v_n[j]));
                 }
-                const v = vals.join(",");
+                const v = selFValue + ':' + vals.join(",");
                 const found = t[v] ?? false;
                 if (!t[v]) {
                     res.push(`${pi.fileName}:${pi.line}:  permutation not `+(found === 0 ? 'enought ':'')+`found w=${j} values: ${v}`);

--- a/test/nonBinarySelectors.js
+++ b/test/nonBinarySelectors.js
@@ -1,0 +1,80 @@
+const chai = require("chai");
+const { exec } = require("child_process");
+const { F1Field } = require("ffjavascript");
+const fs = require("fs");
+const path = require("path");
+const assert = chai.assert;
+const { execSync } = require('child_process');
+var tmp = require('tmp-promise');
+const { compile, verifyPil, newConstantPolsArray, newCommitPolsArray } = require("..");
+
+
+describe("Plookup and permutation selectors value Test", async function () {
+
+    const F = new F1Field(0xffffffff00000001n);
+    this.timeout(10000000);
+
+    it("ZKEV-14 Test (plookup)", async () => {
+
+        const pil = await compile(F,
+            `constant %N = 4;
+             namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             namespace PermutationExample(%N);
+             pol constant b1,b2;
+             pol commit a1, a2;
+             b1{a1} in b2{a2};
+            `, null,
+            { compileFromString: true });
+
+        let constPols = newConstantPolsArray(pil);
+        let cmPols = newCommitPolsArray(pil);
+        const L1 = [1,0,0,0];
+        const b1 = [0,5,0,0];
+        const b2 = [6,0,0,0];
+        const a1 = [4,2,3,21];
+        const a2 = [2,6,19,7];
+        for (i = 0; i<4; ++i) {
+            constPols.Global.L1[i] = BigInt(L1[i]);
+            constPols.PermutationExample.b1[i] = BigInt(b1[i]);
+            constPols.PermutationExample.b2[i] = BigInt(b2[i]);
+            cmPols.PermutationExample.a1[i] = BigInt(a1[i]);
+            cmPols.PermutationExample.a2[i] = BigInt(a2[i]);
+        }
+        const res = await verifyPil(F, pil, cmPols, constPols);
+        assert.equal(res, "(string):7:  plookup not found w=1 values: 5:2");
+    });
+
+    it("ZKEV-14 Test (permutation check)", async () => {
+
+        const pil = await compile(F,
+            `constant %N = 4;
+             namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             namespace PermutationExample(%N);
+             pol constant b1,b2;
+             pol commit a1, a2;
+             b1{a1} is b2{a2};
+            `, null,
+            { compileFromString: true });
+
+        let constPols = newConstantPolsArray(pil);
+        let cmPols = newCommitPolsArray(pil);
+        const L1 = [1,0,0,0];
+        const b1 = [0,5,0,0];
+        const b2 = [6,0,0,0];
+        const a1 = [4,2,3,21];
+        const a2 = [2,6,19,7];
+        for (i = 0; i<4; ++i) {
+            constPols.Global.L1[i] = BigInt(L1[i]);
+            constPols.PermutationExample.b1[i] = BigInt(b1[i]);
+            constPols.PermutationExample.b2[i] = BigInt(b2[i]);
+            cmPols.PermutationExample.a1[i] = BigInt(a1[i]);
+            cmPols.PermutationExample.a2[i] = BigInt(a2[i]);
+        }
+        const res = await verifyPil(F, pil, cmPols, constPols);
+        assert.equal(res, "(string):7:  permutation not found w=1 values: 5:2");
+        // assert.containsAllKeys(pil.references, ['Global.L1', 'Global.BYTE']);
+    });
+
+});

--- a/test/permutationCheck.js
+++ b/test/permutationCheck.js
@@ -42,7 +42,7 @@ describe("Permutation Check Verification", async function () {
             cmPols.PermutationExample.a2[i] = BigInt(a2[i]);
         }
         const res = await verifyPil(F, pil, cmPols, constPols);
-        assert.equal(res, "(string):7:  permutation failed. Remaining 1 values: 4");
+        assert.equal(res, "(string):7:  permutation failed. Remaining 1 values: 1:4");
     });
 
 });


### PR DESCRIPTION
Plookup and permutation check selectors only verify if was zero or not. With this fix, checked if not zero and same value.