### PR TITLE
Update public table and global constraint/expressions

### DIFF
--- a/src/pilout.proto
+++ b/src/pilout.proto
@@ -2,15 +2,15 @@ package pilout;
 syntax = "proto3";
 
 message PilOut {
-    string name = 2;
-    bytes baseField = 1;                        // modulus of the base filed
+    string name = 1;
+    bytes baseField = 2;                        // modulus of the base filed
     repeated SubProof proofs = 3;
     repeated uint32 numChallenges = 4;          // number of challenges per stage
     uin32 numProverValues = 5;
     uin32 numPublicValues = 6;
     repeated PublicTable publicTables = 7;
-    repeated Expression expressions = 8;
-    repeated Constraint constraints = 9;        // Constraints that apply only to signals
+    repeated GlobalExpression expressions = 8;
+    repeated GlobalConstraint constraints = 9;  // Constraints that apply only to signals
     repeated Reference references = 10;
 }
 
@@ -24,10 +24,80 @@ message PublicTable {
         PROD = 1;
     }
 
-    uint32 numColumns = 1;
+    uint32 numCols = 1;
     uint32 maxRows = 2;
-    Operand.Expression rowExpression = 3;       // index into global expressions
-    AggregationType aggType = 4;
+    AggregationType aggType = 3;
+    GlobalOperand.Expression rowExpressionIdx = 4;
+}
+
+message GlobalConstraint {
+    GlobalOperand.Expression expressionIdx = 1;
+    optional string debugLine = 2;
+}
+
+message GlobalExpression {
+    message Add {
+        GlobalOperand lhs = 1;
+        GlobalOperand rhs = 2;
+    }
+
+    message Sub {
+        GlobalOperand lhs = 1;
+        GlobalOperand rhs = 2;
+    }
+
+    message Mul {
+        GlobalOperand lhs = 1;
+        GlobalOperand rhs = 2;
+    }
+
+    message Neg {
+        GlobalOperand value = 1;
+    }
+
+    oneof operation {
+        Add add = 1;
+        Sub sub = 2;
+        Mul mul = 3;
+        Neg neg = 4;
+    }
+}
+
+message GlobalOperand {
+    message Constant {
+        BaseFieldElement value = 1;
+    }
+
+    message Challenge {
+        uint32 stage = 1;
+        uint32 idx = 2;         // index relative to the stage
+    }
+
+    message ProverValue {
+        uint32 idx = 1;
+    }
+
+    message PublicValue {
+        uint32 idx = 1;
+    }
+
+    message PublicTableValue {
+        uint32 idx = 1;         // public table index
+        uint32 colIdx = 2;      // column index within the table
+    }
+
+    message Expression {
+        uint32 idx = 1;
+    }
+
+    oneof operand {
+        Constant constant = 1;
+        Challenge challenge = 2;
+        ProverValue proverValue = 3;
+        PublicValue publicValue = 4;
+        PublicTableValue publicTableValue = 5;
+        Expression expression = 6;
+    }
 }
 
 // BASIC AIR
@@ -100,11 +170,6 @@ message Operand {
         uint32 idx = 1;
     }
 
-    message PublicTableValue {
-        uint32 idx = 1;         // public table ID
-        uint32 colIdx = 2;      // column index within the table
-    }
-
     message PeriodicCol {
         uint32 idx = 1;
         sint32 rowOffset = 2;
@@ -130,11 +195,10 @@ message Operand {
         Challenge challenge = 2;
         ProverValue proverValue = 3;
         PublicValue publicValue = 4;
-        PublicTableValue publicTableValue = 5;
-        PeriodicCol periodicCol = 6;
-        FixedCol fixedCol = 7;
-        WitnessCol witnessCol = 8;
-        Expression expression = 9;
+        PeriodicCol periodicCol = 5;
+        FixedCol fixedCol = 6;
+        WitnessCol witnessCol = 7;
+        Expression expression = 8;
     }
 }
 
@@ -158,17 +222,11 @@ message Expression {
         Operand value = 1;
     }
 
-    message Exp {
-        Operand base = 1;
-        uint32 exponent = 2;
-    }
-
     oneof operation {
         Add add = 1;
         Sub sub = 2;
         Mul mul = 3;
         Neg neg = 4;
-        Exp exp = 5;
     }
 }
 

--- a/src/pilout.proto
+++ b/src/pilout.proto
@@ -2,14 +2,20 @@ package pilout;
 syntax = "proto3";
 
 message PilOut {
-    repeated SubProof monolithicProof = 1;
-    repeated Challenge numChallenges = 2;   // number of challenges per stage
-    repeated Reference references = 3;
-    uin32 nProverValues = 4;
-    uin32 nPublic = 5;
-    repeated PublicTable publicTables = 6;
-    repeated Expression globalExpressions = 7;
-    repeated Constraint globalConstraints = 8;    // Constraints that affect only to signals.
+    string name = 2;
+    bytes baseField = 1;                        // modulus of the base filed
+    repeated SubProof proofs = 3;
+    repeated uint32 numChallenges = 4;          // number of challenges per stage
+    uin32 numProverValues = 5;
+    uin32 numPublicValues = 6;
+    repeated PublicTable publicTables = 7;
+    repeated Expression expressions = 8;
+    repeated Constraint constraints = 9;        // Constraints that apply only to signals
+    repeated Reference references = 10;
+}
+
+message BaseFieldElement {
+    bytes value = 1;
 }
 
 message PublicTable {
@@ -19,10 +25,9 @@ message PublicTable {
     }
 
     uint32 numColumns = 1;
-    uint32 maxSize = 2;
-    uint32 challange1Id = 3;
-    uint32 challange2Id = 4;
-    AggregationType aggType = 5;
+    uint32 maxRows = 2;
+    Operand.Expression rowExpression = 3;       // index into global expressions
+    AggregationType aggType = 4;
 }
 
 // BASIC AIR
@@ -39,11 +44,11 @@ message SubProof {
 }
 
 message PeriodicCol {
-    repeated bytes values = 1;              // Only the cycle
+    repeated BaseFieldElement values = 1;   // Only the cycle
 }
 
 message FixedCol {
-    repeated bytes values = 1;
+    repeated bytes values = 1;              // should this also be BaseFieldElement?
 }
 
 message Constraint {
@@ -79,7 +84,7 @@ message Constraint {
 
 message Operand {
     message Constant {
-        bytes value = 1;
+        BaseFieldElement value = 1;
     }
 
     message Challenge {
@@ -87,16 +92,17 @@ message Operand {
         uint32 idx = 2;     // index relative to the stage
     }
 
-    message Public {
-        uint32 idx = 1;
-    }
-
     message ProverValue {
         uint32 idx = 1;
     }
 
-    message PublicTable {
+    message PublicValue {
         uint32 idx = 1;
+    }
+
+    message PublicTableValue {
+        uint32 idx = 1;         // public table ID
+        uint32 colIdx = 2;      // column index within the table
     }
 
     message PeriodicCol {
@@ -122,14 +128,13 @@ message Operand {
     oneof operand {
         Constant constant = 1;
         Challenge challenge = 2;
-        Public public = 3;
-        ProverValue proverValue = 4;
-        PublicTable publicTable = 5;
-        GlobalPublic globalPublic = 6;
-        PeriodicCol periodicCol = 7;
-        FixedCol fixedCol = 8;
-        WitnessCol witnessCol = 9;
-        Expression expression = 10;
+        ProverValue proverValue = 3;
+        PublicValue publicValue = 4;
+        PublicTableValue publicTableValue = 5;
+        PeriodicCol periodicCol = 6;
+        FixedCol fixedCol = 7;
+        WitnessCol witnessCol = 8;
+        Expression expression = 9;
     }
 }
 
@@ -191,7 +196,7 @@ message Reference {
     optional string debugLine = 7;
 }
 
-// FRONT-END (this this hints?)
+// FRONT-END (is this hints?)
 // ------------------------------------------------------------------------------------------------
 
 enum FrontEndFieldType {


### PR DESCRIPTION
This PR consists of 2 commits:

- In the first commit I did some minor cleanup and update the structure of `PublicTable`. 
- In the second commit, I re-introduced `GlobalConstraint`, `GlobalExpression`, and `GlobalOperand`. If we don't like this changes, it would be easy to roll this back.

Having `GlobalConstraint`, `GlobalExpression`, and `GlobalOperand` does make things a bit more verbose, but I think it is cleaner because:
- My understanding is that `FirstRow`, `LastRow`, etc. is not relevant to global constraints.
- Global expressions cannot access such things as fixed columns, periodic columns, and witness columns.
- Local expressions cannot access public table rows.

Regarding public tables: it seems to me that trying to emulate this logic via regular public inputs and prover values would add a lot of complexity. With the current approach, verifiers which can handle variable-size inputs (i.e., VMs) can handle public inputs trivially, and I don't think it would be too difficult for circuit-based verifiers either.

Specifically, I'm imagining that for every public table there will be a `numRows` input. A Circuit-based verifier could iterate through all the rows up to `maxRows` and include only the rows up to `numRows` into the aggregated result (the rest could be multiplied by either 0 or 1, depending on the aggregation type).

In the current approach, the result of public table aggregation is expected to be provided as a `prover_value`, and we'd also need to have a global constraint to make sure this `prover_value` is equal to the result of public table aggregation. (btw, I'm assuming that prover values are in the extension field - correct?).

A couple of other notes:
- I removed the `exp` operation - I think we can manage without it.
- I added `name` and `baseField` to `PilOut` message. I think `baseField` is good to have here in case we have different fields in the future.
- I added `BaseFieldElement` message and used it in `PeriodicCol`. Should we do the same for `FixedCol`?
- I think we should rename `PilOut` and `SubProof` messages into something else. I'll try to think of better names for them.