### PR TITLE
Adapting polsArray so that works only with symbols, not the pil

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "tmp-promise": "^3.0.3",
-    "yargs": "^17.2.1"
+    "yargs": "^17.2.1",
+    "fastfile": "^0.0.20"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/src/pil_verifier.js
+++ b/src/pil_verifier.js
@@ -1,8 +1,8 @@
-const { assert } = require("chai");
-const { options } = require("yargs");
 const { log2, getKs, getRoots } = require("./utils.js");
 
 module.exports = async function verifyPil(F, pil, cmPols, constPols, config = {}) {
+
+    if(F.p === 18446744069414584321n) F.w = getRoots(F);
 
     const res = [];
 
@@ -375,8 +375,7 @@ function getConnectionMap(F, N, nk) {
     const m = new Array(1<<16);
     const ks = [1n, ...getKs(F, nk-1)];
     let w = F.one;
-    const roots = getRoots(F);
-    const wi = roots[pow];
+    const wi = F.w[pow];
     for (let i=0; i<N; i++ ) {
         if ((i%10000) == 0) console.log(`Building cm.. ${i}/${N}`);
         for (j=0; j<ks.length; j++) {

--- a/src/polsarray.js
+++ b/src/polsarray.js
@@ -1,79 +1,119 @@
+const { F1Field, BigBuffer: BigBufferFr } = require("ffjavascript");
 const fs= require("fs");
+const fastFile = require("fastfile");
+const { BigBuffer } = require("./bigbuffer");
+const { getRoots } = require("./utils");
 
-function newConstantPolsArray(pil) {
-    const pa = new PolsArray(pil, "constant");
+function newConstantPolsArray(pil, F) {
+    if(!F) F = new F1Field("0xFFFFFFFF00000001");
+    if(F.p === 18446744069414584321n) F.w = getRoots(F);
+	
+    const symbols = [];
+    for (const polRef in pil.references) {
+        const polInfo = pil.references[polRef];
+        if(polInfo.type !== "constP") continue;
+        symbols.push({name: polRef, idx: polInfo.id, length: polInfo.len});
+    }
+
+    const degree = pil.references[Object.keys(pil.references)[0]].polDeg;
+    const pa = new PolsArray(symbols, degree, "constant", F);
     return pa;
 }
 
-function newCommitPolsArray(pil) {
-    const pa = new PolsArray(pil, "commit");
+function newCommitPolsArray(pil, F) {
+    if(!F) F = new F1Field("0xFFFFFFFF00000001");
+    if(F.p === 18446744069414584321n) F.w = getRoots(F);
+
+    const symbols = [];
+    for (const polRef in pil.references) {
+        const polInfo = pil.references[polRef];
+        if(polInfo.type !== "cmP") continue;
+        symbols.push({name: polRef, idx: polInfo.id, length: polInfo.len});
+    }
+
+    const degree = pil.references[Object.keys(pil.references)[0]].polDeg;
+    const pa = new PolsArray(symbols, degree, "commit", F);
+    return pa;
+}
+
+function newConstantPolsArrayPil2(symbols, degree, F) {
+    if(!F) F = new F1Field("0xFFFFFFFF00000001");
+    if(F.p === 18446744069414584321n) F.w = getRoots(F);
+
+    const fixedSymbols = [];
+    for (let i = 0; i < symbols.length; ++i) {
+        if(symbols[i].type !== 1) continue;
+        fixedSymbols.push({name: symbols[i].name, idx: symbols[i].id, length: symbols[i].length});
+    }
+
+    const pa = new PolsArray(fixedSymbols, degree, "constant", F);
+    return pa;
+}
+
+function newCommitPolsArrayPil2(symbols, degree, F) {
+    if(!F) F = new F1Field("0xFFFFFFFF00000001");
+    if(F.p === 18446744069414584321n) F.w = getRoots(F);
+
+    const witnessSymbols = [];
+    for (let i = 0; i < symbols.length; ++i) {
+        if(symbols[i].type !== 3) continue;
+        witnessSymbols.push({name: symbols[i].name, idx: symbols[i].id, length: symbols[i].length});
+    }
+
+    const pa = new PolsArray(witnessSymbols, degree, "commit", F);
     return pa;
 }
 
 module.exports.newConstantPolsArray = newConstantPolsArray;
 module.exports.newCommitPolsArray = newCommitPolsArray;
 
+module.exports.newConstantPolsArrayPil2 = newConstantPolsArrayPil2;
+module.exports.newCommitPolsArrayPil2 = newCommitPolsArrayPil2;
 
 class PolsArray {
-    constructor(pil, type) {
-        if (type == "commit") {
-            this.$$nPols = pil.nCommitments;
-        } else if (type == "constant") {
-            this.$$nPols = pil.nConstants;
-        } else {
-            throw new Error("need to specify if you want commited or constant pols")
-        }
-
+    constructor(symbols, degree, type, F) {
+        if (type != "commit" && type != "constant") throw new Error("need to specify if you want commited or constant pols");
+        
         this.$$def = {};
         this.$$defArray = [];
         this.$$array = [];
-        for (let refName in pil.references) {
-            if (pil.references.hasOwnProperty(refName)) {
-                const ref = pil.references[refName];
-                if ((ref.type == "cmP" && type == "commit") ||
-                    (ref.type == "constP" && type == "constant")) {
-                    const [nameSpace, namePol] = refName.split(".");
-                    if (!this[nameSpace]) this[nameSpace] = {};
-                    if (!this.$$def[nameSpace]) this.$$def[nameSpace] = {};
 
-                    if (ref.isArray) {
-                        this[nameSpace][namePol] = [];
-                        this.$$def[nameSpace][namePol] = [];
-                        for (let i=0; i<ref.len; i++) {
-                            const polProxy = new Array(ref.polDeg);
-//                            const polProxy = createPolProxy(this, ref.id + i, ref.polDeg);
-                            this[nameSpace][namePol][i] = polProxy;
-                            this.$$defArray[ref.id + i] = {
-                                name: refName,
-                                id: ref.id + i,
-                                idx: i,
-                                elementType: ref.elementType,
-                                polDeg: ref.polDeg
-                            }
-                            this.$$def[nameSpace][namePol][i] = this.$$defArray[ref.id + i];
-                            this.$$array[ref.id+i] = polProxy;
-                        }
-                    } else {
-                        const polProxy = new Array(ref.polDeg);
-                        // const polProxy = createPolProxy(this, ref.id, ref.polDeg);
-                        this[nameSpace][namePol] = polProxy;
-                        this.$$defArray[ref.id] = {
-                            name: refName,
-                            id: ref.id,
-                            elementType: ref.elementType,
-                            polDeg: ref.polDeg
-                        }
-                        this.$$def[nameSpace][namePol] = this.$$defArray[ref.id];
-                        this.$$array[ref.id] = polProxy;
+        this.F = F;
+        for(let i = 0; i < symbols.length; ++i) {
+            const symbol = symbols[i];
+            const name = symbol.name;
+            const [nameSpace, namePol] = name.split(".");
+            if (!this[nameSpace]) this[nameSpace] = {};
+            if (!this.$$def[nameSpace]) this.$$def[nameSpace] = {};
+            if (symbol.length > 0) {
+                this[nameSpace][namePol] = [];
+                this.$$def[nameSpace][namePol] = [];
+                for(let j=0; j < symbol.length; ++j) {
+                    const polProxy = new Array(degree);
+                    const polId = symbol.idx + j;
+                    this[nameSpace][namePol][j] = polProxy;
+                    this.$$defArray[polId] = {
+                        name: name,
+                        id: polId,
+                        idx: j,
+                        polDeg: degree
                     }
+                    this.$$def[nameSpace][namePol][j] = this.$$defArray[polId];
+                    this.$$array[polId] = polProxy;
+                }   
+            } else {
+                const polProxy = new Array(degree);
+                this[nameSpace][namePol] = polProxy;
+                this.$$defArray[symbol.idx] = {
+                    name: name,
+                    id: symbol.idx,
+                    polDeg: degree
                 }
+                this.$$def[nameSpace][namePol] = this.$$defArray[symbol.idx];
+                this.$$array[symbol.idx] = polProxy;
             }
         }
-        for (let i=0; i<this.$$nPols; i++) {
-            if (!this.$$defArray[i]) {
-                throw new Error("Invalid pils sequence");
-            }
-        }
+
         this.$$nPols = this.$$defArray.length;
         if (this.$$defArray.length>0) {
             this.$$n = this.$$defArray[0].polDeg;
@@ -143,12 +183,11 @@ class PolsArray {
         await fd.close();
     }
 
-    writeToBuff(buff, pos) {
+    writeToBuff(buff) {
         if (typeof buff == "undefined") {
             const constBuffBuff = new ArrayBuffer(this.$$n*this.$$nPols*8);
             buff = new BigUint64Array(constBuffBuff);
         }
-        const buff64 = new BigUint64Array(buff.buffer, buff.byteOffset + pos, this.$$n*this.$$nPols);
         let p=0;
         for (let i=0; i<this.$$n; i++) {
             for (let j=0; j<this.$$nPols; j++) {
@@ -158,16 +197,183 @@ class PolsArray {
         return buff;
     }
 
-    writeToBigBuffer(buff, pos) {
+    writeToBigBuffer(buff, nPols) {
+        if(!nPols) nPols = this.$$nPols;
         if (typeof buff == "undefined") {
-            buff = new BigBuffer(constBuffBuff);
+            buff = new BigBuffer(this.$$n*this.$$nPols);
         }
         let p=0;
         for (let i=0; i<this.$$n; i++) {
             for (let j=0; j<this.$$nPols; j++) {
-                buff.setElement(p++, (this.$$array[j][i] < 0n) ? (this.$$array[j][i] + 0xffffffff00000001n) : this.$$array[j][i]);
+                const value = (this.$$array[j][i] < 0n) ? (this.$$array[j][i] + this.F.p) : this.$$array[j][i];
+                buff.setElement(p++, value);
+                
+            }
+            for(let i = this.$$nPols; i < nPols; ++i) buff.setElement(p++, 0n);
+        }
+        return buff;
+    }
+
+    async loadFromFileFr(fileName, Fr) {
+
+        if(Fr.p !== this.F.p) throw new Error("Curve Prime doesn't match");
+        const fd = await fastFile.readExisting(fileName);
+
+        const MaxBuffSize = 1024*1024*256; 
+        const totalSize = this.$$nPols*this.$$n*this.F.n8;
+
+        console.log(`Reading buffer with total size ${totalSize/1024/1024/8}...`);
+
+        const buff = await fd.read(totalSize);
+
+        console.log("Buffer read. Storing values...")
+
+        let i=0;
+        let j=0;
+        for(let k = 0; k < totalSize; k += this.F.n8) {
+            if(k%MaxBuffSize == 0) console.log(`Storing ${fileName}.. ${k/1024/1024/8} of ${totalSize/1024/1024/8}`);
+            this.$$array[i++][j] = BigInt(Fr.toString(buff.slice(k, k+this.F.n8)));
+            if (i==this.$$nPols) {
+                i=0;
+                j++;
             }
         }
+
+        console.log("File loaded.")
+
+        await fd.close();
+    }
+
+    async writeBuffer(fd, values, pos, Fr) {
+        const n8r = this.F.n8;
+        const buff = new Uint8Array(values.length*n8r);
+
+        for(let k = 0; k < values.length; ++k) {
+            buff.set(Fr.e(values[k]), k*n8r);
+        }
+
+        await fd.write(buff, pos);
+    }
+
+    async saveToFileFr(fileName, Fr) {
+        if(Fr.p !== this.F.p) throw new Error("Curve Prime doesn't match");
+        const fd =await fastFile.createOverride(fileName);
+
+        const n8r = this.F.n8;
+
+        const MaxBuffSize = 1024*1024*256; 
+        const totalSize = this.$$nPols*this.$$n*n8r;
+
+        const buff = new Uint8Array(totalSize);
+
+        let p = 0;
+        for (let i=0; i<this.$$n; i++) {
+            for (let j=0; j<this.$$nPols; j++) {
+                if(p%MaxBuffSize == 0) console.log(`saving ${fileName}.. ${p/1024/1024/8} of ${totalSize/1024/1024/8}`);
+                const v = (this.$$array[j][i] < 0n) ? (this.$$array[j][i] + this.F.p) : this.$$array[j][i];
+                buff.set(Fr.e(v), p);
+                p += n8r;            
+            }
+        }
+
+        console.log("Writting buffer...")
+        
+        await fd.write(buff);
+
+        console.log("File written.")
+
+        await fd.close();
+    }
+
+    async loadFromFileFrLE(fileName) {
+
+        const fd =await fs.promises.open(fileName, "r");
+
+        const MaxBuffSize = 1024*1024*256;  //  256Mb
+        const totalSize = this.$$nPols*this.$$n*this.F.n8;
+        const buff = new Uint8Array((Math.min(totalSize, MaxBuffSize)));
+
+        let i=0;
+        let j=0;
+        let p=0;
+        let n;
+        for (let k=0; k<totalSize; k+= n) {
+            console.log(`loading ${fileName}.. ${k/1024/1024/8} of ${totalSize/1024/1024/8}` );
+            n = Math.min(buff.length, totalSize-k);
+            const res = await fd.read({buffer: buff, offset: 0, position: p, length: n});
+            if (n != res.bytesRead) {
+                console.log(`n: ${n} bytesRead: ${res.bytesRead} div: ${res.bytesRead}`);
+                return;
+            }
+            n = res.bytesRead;
+            p += n;
+            for (let l=0; l<n; l+=this.F.n8) {
+                this.$$array[i++][j] = this.F.fromRprLE(buff, l);
+                if (i==this.$$nPols) {
+                    i=0;
+                    j++;
+                }
+            }
+        }
+
+        await fd.close();
+
+    }
+
+    async saveToFileFrLE(fileName) {
+
+        const fd =await fs.promises.open(fileName, "w+");
+
+        const MaxBuffSize = 1024*1024*256;  //  256Mb
+        const totalSize = this.$$nPols*this.$$n*this.F.n8;
+        const buff = new Uint8Array(Math.min(totalSize, MaxBuffSize));
+        let p=0;
+        let k=0;
+        for (let i=0; i<this.$$n; i++) {
+            for (let j=0; j<this.$$nPols; j++) {
+                const element = (this.$$array[j][i] < 0n) ? (this.$$array[j][i] + this.F.p) : this.$$array[j][i];
+                this.F.toRprLE(buff, p, element);
+                p += this.F.n8;
+
+                if(p == buff.length) {
+                    console.log(`writting ${fileName}.. ${k/1024/1024/8} of ${totalSize/1024/1024/8}` );
+                    await fd.write(buff);
+                    p=0;
+                    ++k;
+                }
+            }
+        }
+
+	    if (p) {
+            const buff8 = new Uint8Array(buff.buffer, 0, p);
+            await fd.write(buff8);
+        }
+
+        await fd.close();
+    }
+
+    async writeToBigBufferFr(buff, Fr, nPols) {
+        if(!nPols) nPols = this.$$nPols;
+        if(Fr.p !== this.F.p) throw new Error("Curve Prime doesn't match");
+
+        const n8r = this.F.n8;
+
+        if (typeof buff == "undefined") {
+            buff = new BigBufferFr(this.$$n*this.$$nPols*n8r); 
+        }
+        let p=0;
+        for (let i=0; i<this.$$n; i++) {
+            for (let j=0; j<this.$$nPols; j++) {
+                const value = (this.$$array[j][i] < 0n) ? (this.$$array[j][i] + this.F.p) : this.$$array[j][i];
+                buff.set(Fr.e(value), p);
+                p += n8r;
+            }
+            for(let i = this.$$nPols; i < nPols; ++i) {
+                buff.set(Fr.zero, p);
+                p += n8r;
+            }
+        }
+
         return buff;
     }
 }

--- a/test/compileFromString.js
+++ b/test/compileFromString.js
@@ -6,7 +6,7 @@ const path = require("path");
 const assert = chai.assert;
 const { execSync } = require('child_process');
 var tmp = require('tmp-promise');
-const { compile, newConstantPolsArray, newCommitPolsArray } = require("..");
+const { compile } = require("..");
 
 
 describe("CompileFromString (string compilation - library)", async function () {

--- a/test/connectCheck.js
+++ b/test/connectCheck.js
@@ -1,19 +1,14 @@
 const chai = require("chai");
-const { exec } = require("child_process");
 const { F1Field } = require("ffjavascript");
-const fs = require("fs");
-const path = require("path");
 const assert = chai.assert;
-const { execSync } = require('child_process');
-var tmp = require('tmp-promise');
 const { compile, verifyPil, newConstantPolsArray, newCommitPolsArray, getRoots, getKs } = require("..");
 
 describe("Connect Verification", async function () {
 
-    const F = new F1Field(0xffffffff00000001n);
     this.timeout(10000000);
 
-    it("Connect Test", async () => {
+    it("Connect Test field goldilocks", async () => {
+        const F = new F1Field(0xffffffff00000001n);
 
         const pil = await compile(F,
             `constant %N = 4;
@@ -26,8 +21,8 @@ describe("Connect Verification", async function () {
             `, null,
             { compileFromString: true });
 
-        let constPols = newConstantPolsArray(pil);
-        let cmPols = newCommitPolsArray(pil);
+        let constPols = newConstantPolsArray(pil, F);
+        let cmPols = newCommitPolsArray(pil, F);
 
         const N = 4;
         const pow = 2;
@@ -63,7 +58,59 @@ describe("Connect Verification", async function () {
         connect(constPols.ConnectExample.B, 0, constPols.ConnectExample.A, 3);
         connect(constPols.ConnectExample.C, 1, constPols.ConnectExample.B, 3);
         const res = await verifyPil(F, pil, cmPols, constPols);
-        //assert.equal(res, "(string):7:  permutation failed. Remaining 1 values: 1:4");
+        assert(res.length === 0);
+    });
+
+    it("Connect Test field bn128", async () => {
+        const F = new F1Field(21888242871839275222246405745257275088548364400416034343698204186575808495617n);
+
+        const pil = await compile(F,
+            `constant %N = 4;
+             namespace Global(%N);
+             pol constant L1;    // 1, 0, 0, 0, 0
+             namespace ConnectExample(%N);
+             pol constant A, B, C;
+             pol commit a, b, c;
+             {a,b,c} connect {A,B,C};
+            `, null,
+            { compileFromString: true });
+
+        let constPols = newConstantPolsArray(pil, F);
+        let cmPols = newCommitPolsArray(pil, F);
+
+        const N = 4;
+        const pow = 2;
+
+        const ks = getKs(F, 2);
+        const wi = F.w[pow];
+        let w = F.one;
+        for (let i=0; i<N; i++) {
+            constPols.ConnectExample.A[i] = w;
+            constPols.ConnectExample.B[i] = F.mul(w, ks[0]);
+            constPols.ConnectExample.C[i] = F.mul(w, ks[1]);
+            w = F.mul(w, wi);
+        }
+
+        function connect(p1, i1, p2, i2) {
+            [p1[i1], p2[i2]] = [p2[i2], p1[i1]];
+        }
+
+        const L1 = [1,0,0,0];
+        const a = [2,6,5,5];
+        const b = [5,1,2,3];
+        const c = [1,3,6,1];
+        for (i = 0; i<4; ++i) {
+            constPols.Global.L1[i] = BigInt(L1[i]);
+            cmPols.ConnectExample.a[i] = BigInt(a[i]);
+            cmPols.ConnectExample.b[i] = BigInt(b[i]);
+            cmPols.ConnectExample.c[i] = BigInt(c[i]);
+        }
+        connect(constPols.ConnectExample.A, 0, constPols.ConnectExample.B, 2);
+        connect(constPols.ConnectExample.A, 1, constPols.ConnectExample.C, 2);
+        connect(constPols.ConnectExample.B, 0, constPols.ConnectExample.A, 2);
+        connect(constPols.ConnectExample.B, 0, constPols.ConnectExample.A, 3);
+        connect(constPols.ConnectExample.C, 1, constPols.ConnectExample.B, 3);
+        const res = await verifyPil(F, pil, cmPols, constPols);
     });
 
 });

--- a/test/nonBinarySelectors.js
+++ b/test/nonBinarySelectors.js
@@ -1,11 +1,7 @@
 const chai = require("chai");
-const { exec } = require("child_process");
 const { F1Field } = require("ffjavascript");
 const fs = require("fs");
-const path = require("path");
 const assert = chai.assert;
-const { execSync } = require('child_process');
-var tmp = require('tmp-promise');
 const { compile, verifyPil, newConstantPolsArray, newCommitPolsArray } = require("..");
 
 const commonTestCode = async function (F, name, specificPilProgram, values) {
@@ -20,8 +16,8 @@ const commonTestCode = async function (F, name, specificPilProgram, values) {
         fs.writeFileSync(`tmp/${name}.pil`, pilProgram);
         fs.writeFileSync(`tmp/${name}.pil.json`, JSON.stringify(pil));
 
-        let constPols = newConstantPolsArray(pil);
-        let cmPols = newCommitPolsArray(pil);
+        let constPols = newConstantPolsArray(pil, F);
+        let cmPols = newCommitPolsArray(pil, F);
         const L1 = [1,0,0,0];
 
         for (i = 0; i<4; ++i) {

--- a/test/permutationCheck.js
+++ b/test/permutationCheck.js
@@ -1,11 +1,6 @@
 const chai = require("chai");
-const { exec } = require("child_process");
 const { F1Field } = require("ffjavascript");
-const fs = require("fs");
-const path = require("path");
 const assert = chai.assert;
-const { execSync } = require('child_process');
-var tmp = require('tmp-promise');
 const { compile, verifyPil, newConstantPolsArray, newCommitPolsArray } = require("..");
 
 
@@ -27,8 +22,8 @@ describe("Permutation Check Verification", async function () {
             `, null,
             { compileFromString: true });
 
-        let constPols = newConstantPolsArray(pil);
-        let cmPols = newCommitPolsArray(pil);
+        let constPols = newConstantPolsArray(pil, F);
+        let cmPols = newCommitPolsArray(pil, F);
         const L1 = [1,0,0,0];
         const b1 = [1,1,1,0];
         const b2 = [1,1,1,1];

--- a/test/polsarray.test.js
+++ b/test/polsarray.test.js
@@ -1,5 +1,5 @@
 const chai = require("chai");
-const { F1Field } = require("ffjavascript");
+const { F1Field, getCurveFromName } = require("ffjavascript");
 const fs = require("fs");
 const path = require("path");
 const assert = chai.assert;
@@ -10,7 +10,17 @@ const { compile, newConstantPolsArray, newCommitPolsArray } = require("..");
 describe("PolsArray", async function () {
     this.timeout(10000000);
 
-    it("It should create, save and rescover pols Array", async () => {
+    let curve;
+
+    before(async () => {
+        curve = await getCurveFromName("bn128");
+    })
+
+    after(async () => {
+        await curve.terminate();
+    });
+
+    it("It should create, save and recover pols Array with field goldilocks", async () => {
         const F = new F1Field(0xffffffff00000001n);
 
         const pil = await compile(F, path.join(__dirname, "examples", "arrays.pil"));
@@ -35,12 +45,126 @@ describe("PolsArray", async function () {
         await constPols.saveToFile(fileNameConst);
         await cmPols.saveToFile(fileNameCm);
 
-        const buff2 = new BigInt64Array(constPols.$$n*constPols.$$nPols + cmPols.$$n*cmPols.$$nPols);
-
-        const constPols2 = newConstantPolsArray(pil, buff2, 0);
-        const cmPols2 = newCommitPolsArray(pil, buff2, constPols.$$n*constPols.$$nPols*8);
+        const constPols2 = newConstantPolsArray(pil);
+        const cmPols2 = newCommitPolsArray(pil);
         await constPols2.loadFromFile(fileNameConst);
         await cmPols2.loadFromFile(fileNameCm);
+
+        assert.equal(constPols.$$n, constPols2.$$n);
+        assert.equal(constPols.$$nPols, constPols2.$$nPols);
+
+        for (let i=0; i<constPols2.$$n; i++) {
+            assert.equal(constPols.Arrays2.d[0][i], constPols2.Arrays2.d[0][i]);
+            assert.equal(constPols.Arrays2.d[1][i], constPols2.Arrays2.d[1][i]);
+            assert.equal(cmPols.Arrays2.c[i], cmPols2.Arrays2.c[i]);
+            assert.equal(cmPols.Arrays1.a[i], cmPols2.Arrays1.a[i]);
+            assert.equal(cmPols.Arrays1.b[0][i], cmPols2.Arrays1.b[0][i]);
+            assert.equal(cmPols.Arrays1.b[1][i], cmPols2.Arrays1.b[1][i]);
+            assert.equal(cmPols.Arrays1.b[2][i], cmPols2.Arrays1.b[2][i]);
+            assert.equal(cmPols.Arrays1.c[i], cmPols2.Arrays1.c[i]);
+        }
+        for (let i=0; i<constPols2.$$n; i++) {
+            for (let j=0; j<constPols2.$$nPols; j++) {
+                assert.equal(constPols.$$array[j][i], constPols2.$$array[j][i])
+            }
+            for (let j=0; j<cmPols2.$$nPols; j++) {
+                assert.equal(cmPols.$$array[j][i], cmPols2.$$array[j][i])
+            }
+        }
+
+        await fs.promises.unlink(fileNameConst);
+        await fs.promises.unlink(fileNameCm);
+    });
+
+    it("It should create, save and recover pols Array with field BN128", async () => {
+        const F = new F1Field(21888242871839275222246405745257275088548364400416034343698204186575808495617n);
+
+        const pil = await compile(F, path.join(__dirname, "examples", "arrays.pil"));
+
+        const constPols = newConstantPolsArray(pil, F);
+        const cmPols = newCommitPolsArray(pil, F);
+
+        let constant = 21888242871839275222246405745257275088548364400416034343698204186575808495617n / 2n;
+
+        let p=constant + 1n;
+        for (let i=0; i<constPols.$$n; i++) {
+            constPols.Arrays2.d[0][i] = BigInt(p++);
+            constPols.Arrays2.d[1][i] = BigInt(p++);
+            cmPols.Arrays2.c[i] = BigInt(p++);
+            cmPols.Arrays1.a[i] = BigInt(p++);
+            cmPols.Arrays1.b[0][i] = BigInt(p++);
+            cmPols.Arrays1.b[1][i] = BigInt(p++);
+            cmPols.Arrays1.b[2][i] = BigInt(p++);
+            cmPols.Arrays1.c[i] = BigInt(p++);
+        }
+
+        fileNameConst = await tmp.tmpName();
+        fileNameCm = await tmp.tmpName();
+        await constPols.saveToFileFr(fileNameConst, curve.Fr);
+        await cmPols.saveToFileFr(fileNameCm, curve.Fr);
+
+        const constPols2 = newConstantPolsArray(pil, F);
+        const cmPols2 = newCommitPolsArray(pil, F);
+        await constPols2.loadFromFileFr(fileNameConst, curve.Fr);
+        await cmPols2.loadFromFileFr(fileNameCm, curve.Fr);
+
+        assert.equal(constPols.$$n, constPols2.$$n);
+        assert.equal(constPols.$$nPols, constPols2.$$nPols);
+
+        for (let i=0; i<constPols2.$$n; i++) {
+            assert.equal(constPols.Arrays2.d[0][i], constPols2.Arrays2.d[0][i]);
+            assert.equal(constPols.Arrays2.d[1][i], constPols2.Arrays2.d[1][i]);
+            assert.equal(cmPols.Arrays2.c[i], cmPols2.Arrays2.c[i]);
+            assert.equal(cmPols.Arrays1.a[i], cmPols2.Arrays1.a[i]);
+            assert.equal(cmPols.Arrays1.b[0][i], cmPols2.Arrays1.b[0][i]);
+            assert.equal(cmPols.Arrays1.b[1][i], cmPols2.Arrays1.b[1][i]);
+            assert.equal(cmPols.Arrays1.b[2][i], cmPols2.Arrays1.b[2][i]);
+            assert.equal(cmPols.Arrays1.c[i], cmPols2.Arrays1.c[i]);
+        }
+        for (let i=0; i<constPols2.$$n; i++) {
+            for (let j=0; j<constPols2.$$nPols; j++) {
+                assert.equal(constPols.$$array[j][i], constPols2.$$array[j][i])
+            }
+            for (let j=0; j<cmPols2.$$nPols; j++) {
+                assert.equal(cmPols.$$array[j][i], cmPols2.$$array[j][i])
+            }
+        }
+
+        await fs.promises.unlink(fileNameConst);
+        await fs.promises.unlink(fileNameCm);
+    });
+
+    it("It should create, save and recover pols Array with field BN128 Little Endian", async () => {
+        const F = new F1Field(21888242871839275222246405745257275088548364400416034343698204186575808495617n);
+
+        const pil = await compile(F, path.join(__dirname, "examples", "arrays.pil"));
+
+        const constPols = newConstantPolsArray(pil, F);
+        const cmPols = newCommitPolsArray(pil, F);
+
+        let constant = 21888242871839275222246405745257275088548364400416034343698204186575808495617n / 2n;
+
+        let p=constant + 1n;
+        for (let i=0; i<constPols.$$n; i++) {
+            constPols.Arrays2.d[0][i] = BigInt(p++);
+            constPols.Arrays2.d[1][i] = BigInt(p++);
+            cmPols.Arrays2.c[i] = BigInt(p++);
+            cmPols.Arrays1.a[i] = BigInt(p++);
+            cmPols.Arrays1.b[0][i] = BigInt(p++);
+            cmPols.Arrays1.b[1][i] = BigInt(p++);
+            cmPols.Arrays1.b[2][i] = BigInt(p++);
+            cmPols.Arrays1.c[i] = BigInt(p++);
+        }
+
+        fileNameConst = await tmp.tmpName();
+        fileNameCm = await tmp.tmpName();
+        await constPols.saveToFileFrLE(fileNameConst);
+        await cmPols.saveToFileFrLE(fileNameCm);
+
+        const constPols2 = newConstantPolsArray(pil, F);
+        const cmPols2 = newCommitPolsArray(pil, F);
+        await constPols2.loadFromFileFrLE(fileNameConst);
+        await cmPols2.loadFromFileFrLE(fileNameCm);
 
         assert.equal(constPols.$$n, constPols2.$$n);
         assert.equal(constPols.$$nPols, constPols2.$$nPols);


### PR DESCRIPTION
This PR modifies the way polsArray.js works so that it can handle both, pil1 and pil2. To do so, `PolsArray` class only depends on symbols, not the whole pil. It also adds a few functions so that it can work with fields other than Goldilocks, which uses BigUint64Array. For any other field, BigBuffer, from ffjavascript is used. 
Some tests were added / fixed.