### PR TITLE
PIL2 Library

### DIFF
--- a/src/pil_verifier.js
+++ b/src/pil_verifier.js
@@ -394,10 +394,3 @@ function getConnectionMap(F, N, nk) {
     cacheConnectionMaps[kc] = m;
     return m;
 }
-
-
-
-
-
-
-

--- a/test/pil2/vadcop/std_connect.pil
+++ b/test/pil2/vadcop/std_connect.pil
@@ -1,3 +1,6 @@
+// A this moment, connection arguments are only applicable within the same AIR.
+// However, I think they can be extended to the subproof level.
+
 private function init_challenges() {
     if (!defined(std_alpha)) {
         challenge stage(2) std_alpha;
@@ -7,47 +10,123 @@ private function init_challenges() {
     }
 }
 
-// Take care of the redeclaration
 private function init_coset_constants(int len) {
     global std_ks[len];
 
-    for (int i = 0; i < len; ++i) {
-        std_ks[i] = global constant k[i];
+    std_ks[0] = 1;
+    for (int i = 1; i < len; ++i) {
+        std_ks[i] = global constant k[i-1];
     }
 }
 
-// Two (incompatible??) user interfaces
+// Two user interfaces
 
-// 1] WIP
+// 1] Interface where the user uses the update() method to define the permutation "on the fly"
+//    and when it is done, executes the connect() method to perform the connection argument.
+//    The user also needs to execute init() at the beginning.
+
+// TODO (Héctor): Throw an error if the calling path is not being called correctly?
+
 function connection_init(int opid, expr cols[]) {
-        // connection_update_require(opid, sel, cols);
+    check_opid_and_cols(opid, length(cols), 0, 0);
 }
 
-function connection_connect(int opid, expr cols[]) {
-        // connection_update_provide(opid, sel, cols);
-}
-
-// 2]
-function connection_require(int opid, expr cols[]) {
+private function find_col_index(expr column) {
     use proof.std.connect.`id${opid}`;
 
-    colsR = cols;
+    for (int icol = 0; icol < length(map_cols); ++icol) {
+        if (map_cols[icol] == column) {
+            return icol;
+        }
+    }
+}
+
+function connection_update_one(int opid, expr col1, int row1, expr col2, int row2) {
+    use proof.std.connect.`id${opid}`;
+
+    int col1_index = find_col_index(col1);
+    int col2_index = find_col_index(col2);
+
+    expr tmp = SIDs[col1_index][row1]
+    SIDs[col1_index][row1] = SIDs[col2_index][row2];
+    SIDs[col2_index][row2] = tmp;
+}
+
+function connection_update(int opid, expr col1, int rows1[], expr col2, int rows2[]) {
+    use proof.std.connect.`id${opid}`;
+
+    int len1 = length(rows1);
+    int len2 = length(rows2);
+
+    if (len1 == len2 == 1) {
+        connection_update_one(opid, col1, rows1[0], col2, rows2[0]);
+        return;
+    }
+
+    int col1_index = find_col_index(col1);
+    int col2_index = find_col_index(col2);
+
+    expr SID1 = SIDs[col1_index];
+    expr SID2 = SIDs[col2_index];
+
+    expr SID1_last = SID1[rows1[len1-1]];
+    expr SID2_last = SID2[rows2[len2-1]];
+
+    if (len1 >= 2) {
+        for (int icol = len1 - 2; icol >= 0; --icol) {
+            int row1 = rows1[icol];
+            int row2 = rows1[icol+1];
+
+            SID1[row2] = SID1[row1]
+        }
+    }
+
+    if (len2 >= 2) {
+        for (int icol = len2 - 2; icol >= 0; --icol) {
+            int row1 = rows2[icol];
+            int row2 = rows2[icol+1];
+
+            SID2[row2] = SID2[row1]
+        }
+    }
+
+    SID1[0] = SID2_last;
+    SID2[0] = SID1_last;
+}
+
+// TODO (Héctor): Add a generalisation where more than two columns can be chosen
+
+function connection_connect(int opid) {
+    use proof.std.connect.`id${opid}`;
+
+    connection_update_require(opid, map_cols, 0);
+    connection_update_provide(opid, map_cols, SIDs);
+}
+
+// 2] Interface where the user knows both the inputs (placed in require) and the
+//    permutation (placed in provide) of the argument.
+function connection_require(int opid, expr cols[]) {
+    check_opid_and_cols(opid, length(cols), 0, 1);
+
+    use proof.std.connect.`id${opid}`;
+
+    tmpR = cols;
 
     if (provide == 1) {
-        connection_update_require(opid, cols);
-        connection_update_provide(opid, colsP);
-    } else {
-        connection_update_require(opid, cols);
+        connection_update_provide(opid, cols, tmpP);
     }
+    connection_update_require(opid, cols, 1);
 }
 
 function connection_provide(int opid, expr cols[]) {
+    check_opid_and_cols(opid, length(cols), 1, 1);
+
     use proof.std.connect.`id${opid}`;
 
     if (require == 1) {
-        connection_update_provide(opid, cols);
+        connection_update_provide(opid, tmpR, cols);
     } else {
-        colsP = cols;
+        tmpP = cols;
     }
 }
 
@@ -57,7 +136,7 @@ function connection_provide(int opid, expr cols[]) {
  * @param cols_count number of columns of the connect check
  * @param provide 1 if provide, 0 if require
  */
-private function check_opid_and_cols(int opid, int cols_count, int provide) {
+private function check_opid_and_cols(int opid, int cols_count, int provide, int is_second_interface) {
 
     if (cols_count < 1) {
         error(`The number of columns of connect #${opid} must be at least 1`);
@@ -76,55 +155,76 @@ private function check_opid_and_cols(int opid, int cols_count, int provide) {
     }
 
     container proof.std.connect.`id${opid}` alias connid {
-        int cols;
+        int cols_num;
         int provide = 0;
         int require = 0;
 
-        expr SIDs[]; // TODO: Should I place this one in another place?
+        expr SIDs[];
+        expr map_cols[]; // Used in connection_init()
+
+        // Used in connection_require() and connection_provide()
+        expr tmpR[];
+        expr tmpP[];
     }
 
-    if (connid.cols == 0) {
+    if (connid.cols_num == 0) {
         // first time called
-        connid.cols = cols_count;
+        connid.cols_num = cols_count;
         // add opid on a list to verify at final
         conn.opids[conn.opids_count] = opid;
         ++conn.opids_count;
-    } else if (connid.cols != cols_count) {
-        error(`The number of columns of connect #${opid} must be ${connid.cols}`);
+    } else if (connid.cols_num != cols_count) {
+        error(`The number of columns of connect #${opid} must be ${connid.cols_num}`);
     }
 
-    if (provide) {
-        if (connid.provide > 0) {
-            error(`Connection #${opid} provide was called previously`);
+    if (is_second_interface) {
+        if (provide) {
+            if (connid.provide > 0) {
+                error(`Connection #${opid} provide was called previously`);
+            }
+            ++connid.provide;
+        } else {
+            if (connid.require > 0) {
+                error(`Connection #${opid} require was called previously`);
+            }
+            ++connid.require;
         }
-        ++connid.provide;
     } else {
-        if (connid.require > 0) {
-            error(`Connection #${opid} require was called previously`);
+        // Create a mapping of indexes to set an order of the columns the first time it is called
+        for (int icol = 0; icol < cols_count; ++icol) {
+            connid.map_cols[icol] = cols[icol];
         }
-        ++connid.require;
+
+        init_coset_constants(cols_count);
+
+        col fixed IDEN = [1,omega,..*..,omega**(N-1)]; // {1,𝛚,𝛚²,...,𝛚ᴺ⁻¹}
+
+        // Compute polynomials SID_i(X) := k_i·X
+        for (int icol = 0; icol < cols_count; ++icol) {
+            connid.SIDs[icol] = std_ks[icol] * IDEN;
+        }
     }
 }
 
 /**
- * Given columns C₀,...,Cₙ₋₁, 
- * @param provide boolean indicating if updating a provide or a require
+ * Given columns C₀,...,Cₙ₋₁, it computes the polynomial Cᵢ(X) + alpha·kᵢ·X + beta
  * @param opid (unique) identifier of the connection
- * @param colsP provide columns of the connection
+ * @param colsR require columns of the connection
  */
-function connection_update_require(int opid, expr colsR[]) {
-    // verify if correct opid and cols
-    check_opid_and_cols(opid, length(colsR), 0);
-
+function connection_update_require(int opid, expr colsR[], int is_second_interface) {
     init_challenges();
-    init_coset_constants(length(colsR));
-
-    once col fixed IDEN = [1,omega,..*..,omega**(N-1)]; // {1,𝛚,𝛚²,...,𝛚ᴺ⁻¹}
 
     use proof.std.connect.`id${opid}`;
-    // Compute polynomials SID_i(X) := k_i·X
-    for (int icol = 0; icol < length(colsR); ++icol) {
-        SIDs[icol] = std_ks[icol] * IDEN;
+
+    if (is_second_interface) {
+        init_coset_constants(length(colsR));
+
+        once col fixed IDEN = [1,omega,..*..,omega**(N-1)]; // {1,𝛚,𝛚²,...,𝛚ᴺ⁻¹}
+
+        // Compute polynomials SID_i(X) := k_i·X
+        for (int icol = 0; icol < length(colsR); ++icol) {
+            SIDs[icol] = std_ks[icol] * IDEN;
+        }
     }
 
     for (int icol = 0; icol < length(colsR); ++icol) {
@@ -135,10 +235,13 @@ function connection_update_require(int opid, expr colsR[]) {
     on final air connection_air();
 }
 
+/**
+ * Given columns C₀,...,Cₙ₋₁, and C'₀,...,C'ₙ₋₁, it computes the polynomial Cᵢ(X) + alpha·C'ᵢ(X) + beta
+ * @param opid (unique) identifier of the connection
+ * @param colsR require columns of the connection
+ * @param colsP provide columns of the connection
+ */
 function connection_update_provide(int opid, expr colsR[], expr colsP[]) {
-    // verify if correct opid and cols
-    check_opid_and_cols(opid, length(colsP), 1);
-
     init_challenges();
 
     for (int icol = 0; icol < length(colsP); ++icol) {
@@ -160,7 +263,7 @@ private function connection_air() {
     //  gsum === 'gsum + ------------------------ + --------------------------- + ... + -------------------------- - ------------------------ - ------------------------ - ... - ------------------------
     //                   (f_0 + alpha·X + beta)      (f_1 + alpha·k_1·X + beta)         (f_N + alpha·k_n·X + beta)   (f_0 + alpha·S_0 + beta) · (f_1 + alpha·S_1 + beta)         (f_N + alpha·S_n + beta)
 
-    expr LHS = 0;
+    expr LHS = 1;
     expr RHS1 = 0;
     for (int i = 0; i < length(gsum_require); ++i) {
         LHS = LHS * gsum_require[i];
@@ -198,11 +301,9 @@ private function connection_air() {
     L1' * gsum === 0;
 }
 
-// TODO: We use it for just one opid in the sam air
-
 // It checks wheter there is some connection check without either provide or require
 private function check_connection_was_completed() {
-    for (int opid in air.std.connect.opids) {
+    for (int opid in proof.std.connect.opids) {
         if (proof.std.connect.`id${opid}`.require == 0) {
             error(`Connection #${opid} defined without require`);
         }

--- a/test/pil2/vadcop/std_connect.pil
+++ b/test/pil2/vadcop/std_connect.pil
@@ -214,7 +214,7 @@ private function check_opid_and_cols(int opid, int cols_count, int provide, int 
  * @param opid (unique) identifier of the connection
  * @param colsR require columns of the connection
  */
-function connection_update_require(int opid, expr colsR[], int is_second_interface) {
+private function connection_update_require(int opid, expr colsR[], int is_second_interface) {
     init_challenges();
 
     use proof.std.connect.`id${opid}`;
@@ -244,7 +244,7 @@ function connection_update_require(int opid, expr colsR[], int is_second_interfa
  * @param colsR require columns of the connection
  * @param colsP provide columns of the connection
  */
-function connection_update_provide(int opid, expr colsR[], expr colsP[]) {
+private function connection_update_provide(int opid, expr colsR[], expr colsP[]) {
     init_challenges();
 
     for (int icol = 0; icol < length(colsP); ++icol) {

--- a/test/pil2/vadcop/std_connect.pil
+++ b/test/pil2/vadcop/std_connect.pil
@@ -80,10 +80,7 @@ private function check_opid_and_cols(int opid, int cols_count, int provide) {
         int provide = 0;
         int require = 0;
 
-        expr colsR[];
-        expr colsP[];
-
-        expr SIDs[];
+        expr SIDs[]; // TODO: Should I place this one in another place?
     }
 
     if (connid.cols == 0) {
@@ -125,17 +122,14 @@ function connection_update_require(int opid, expr colsR[]) {
     once col fixed IDEN = [1,omega,..*..,omega**(N-1)]; // {1,𝛚,𝛚²,...,𝛚ᴺ⁻¹}
 
     use proof.std.connect.`id${opid}`;
-    // Define polynomials SID_i(X) := k_i·X
+    // Compute polynomials SID_i(X) := k_i·X
     for (int icol = 0; icol < length(colsR); ++icol) {
         SIDs[icol] = std_ks[icol] * IDEN;
     }
 
-    expr requireEls = [];
     for (int icol = 0; icol < length(colsR); ++icol) {
-        requireEls[] = colsR[icol] + std_alpha*SIDs[icol] + std_beta;
+        air.std.connect.gsum_require[] = colsR[icol] + std_alpha*SIDs[icol] + std_beta;
     }
-
-    air.std.connect.gsum_require[] = requireEls;
 
     // define constraints at the air level
     on final air connection_air();
@@ -147,14 +141,9 @@ function connection_update_provide(int opid, expr colsR[], expr colsP[]) {
 
     init_challenges();
 
-    use proof.std.connect.`id${opid}`;
-
-    expr provideEls = [];
     for (int icol = 0; icol < length(colsP); ++icol) {
-        provideEls[] = colsR[icol] + std_alpha*colsP[icol] + std_beta;
+        air.std.connect.gsum_provide[] = colsR[icol] + std_alpha*colsP[icol] + std_beta;
     }
-
-    air.std.connect.gsum_provide[] = provideEls;
 
     // define constraints at the air level
     on final air connection_air();
@@ -208,6 +197,8 @@ private function connection_air() {
     (gsum - 'gsum) * LHS === RHS;
     L1' * gsum === 0;
 }
+
+// TODO: We use it for just one opid in the sam air
 
 // It checks wheter there is some connection check without either provide or require
 private function check_connection_was_completed() {

--- a/test/pil2/vadcop/std_connect.pil
+++ b/test/pil2/vadcop/std_connect.pil
@@ -1,0 +1,222 @@
+private function init_challenges() {
+    if (!defined(std_alpha)) {
+        challenge stage(2) std_alpha;
+    }
+    if (!defined(std_beta)) {
+        challenge stage(2) std_beta;
+    }
+}
+
+// Take care of the redeclaration
+private function init_coset_constants(int len) {
+    global std_ks[len];
+
+    for (int i = 0; i < len; ++i) {
+        std_ks[i] = global constant k[i];
+    }
+}
+
+// Two (incompatible??) user interfaces
+
+// 1] WIP
+function connection_init(int opid, expr cols[]) {
+        // connection_update_require(opid, sel, cols);
+}
+
+function connection_connect(int opid, expr cols[]) {
+        // connection_update_provide(opid, sel, cols);
+}
+
+// 2]
+function connection_require(int opid, expr cols[]) {
+    use proof.std.connect.`id${opid}`;
+
+    colsR = cols;
+
+    if (provide == 1) {
+        connection_update_require(opid, cols);
+        connection_update_provide(opid, colsP);
+    } else {
+        connection_update_require(opid, cols);
+    }
+}
+
+function connection_provide(int opid, expr cols[]) {
+    use proof.std.connect.`id${opid}`;
+
+    if (require == 1) {
+        connection_update_provide(opid, cols);
+    } else {
+        colsP = cols;
+    }
+}
+
+/**
+ * Verifies the number of columns of same connect check (require, provide) is the same.
+ * @param opid (unique) identifier of the connect check
+ * @param cols_count number of columns of the connect check
+ * @param provide 1 if provide, 0 if require
+ */
+private function check_opid_and_cols(int opid, int cols_count, int provide) {
+
+    if (cols_count < 1) {
+        error(`The number of columns of connect #${opid} must be at least 1`);
+    }
+
+    container proof.std.connect alias conn {
+        // FIX: dynamic arrays not ready
+        int opids_count = 0;
+        int opids[100];
+    }
+
+    container air.std.connect {
+        // FIX: dynamic arrays not ready
+        expr gsum_require[100];
+        expr gsum_provide[100];
+    }
+
+    container proof.std.connect.`id${opid}` alias connid {
+        int cols;
+        int provide = 0;
+        int require = 0;
+
+        expr colsR[];
+        expr colsP[];
+
+        expr SIDs[];
+    }
+
+    if (connid.cols == 0) {
+        // first time called
+        connid.cols = cols_count;
+        // add opid on a list to verify at final
+        conn.opids[conn.opids_count] = opid;
+        ++conn.opids_count;
+    } else if (connid.cols != cols_count) {
+        error(`The number of columns of connect #${opid} must be ${connid.cols}`);
+    }
+
+    if (provide) {
+        if (connid.provide > 0) {
+            error(`Connection #${opid} provide was called previously`);
+        }
+        ++connid.provide;
+    } else {
+        if (connid.require > 0) {
+            error(`Connection #${opid} require was called previously`);
+        }
+        ++connid.require;
+    }
+}
+
+/**
+ * Given columns C₀,...,Cₙ₋₁, 
+ * @param provide boolean indicating if updating a provide or a require
+ * @param opid (unique) identifier of the connection
+ * @param colsP provide columns of the connection
+ */
+function connection_update_require(int opid, expr colsR[]) {
+    // verify if correct opid and cols
+    check_opid_and_cols(opid, length(colsR), 0);
+
+    init_challenges();
+    init_coset_constants(length(colsR));
+
+    once col fixed IDEN = [1,omega,..*..,omega**(N-1)]; // {1,𝛚,𝛚²,...,𝛚ᴺ⁻¹}
+
+    use proof.std.connect.`id${opid}`;
+    // Define polynomials SID_i(X) := k_i·X
+    for (int icol = 0; icol < length(colsR); ++icol) {
+        SIDs[icol] = std_ks[icol] * IDEN;
+    }
+
+    expr requireEls = [];
+    for (int icol = 0; icol < length(colsR); ++icol) {
+        requireEls[] = colsR[icol] + std_alpha*SIDs[icol] + std_beta;
+    }
+
+    air.std.connect.gsum_require[] = requireEls;
+
+    // define constraints at the air level
+    on final air connection_air();
+}
+
+function connection_update_provide(int opid, expr colsR[], expr colsP[]) {
+    // verify if correct opid and cols
+    check_opid_and_cols(opid, length(colsP), 1);
+
+    init_challenges();
+
+    use proof.std.connect.`id${opid}`;
+
+    expr provideEls = [];
+    for (int icol = 0; icol < length(colsP); ++icol) {
+        provideEls[] = colsR[icol] + std_alpha*colsP[icol] + std_beta;
+    }
+
+    air.std.connect.gsum_provide[] = provideEls;
+
+    // define constraints at the air level
+    on final air connection_air();
+}
+
+private function connection_air() {
+    check_connection_was_completed();
+
+    use air.std.connect;
+
+    col witness stage(2) gsum;
+
+    //                            1                              1                                  1                              1                       1                                1
+    //  gsum === 'gsum + ------------------------ + --------------------------- + ... + -------------------------- - ------------------------ - ------------------------ - ... - ------------------------
+    //                   (f_0 + alpha·X + beta)      (f_1 + alpha·k_1·X + beta)         (f_N + alpha·k_n·X + beta)   (f_0 + alpha·S_0 + beta) · (f_1 + alpha·S_1 + beta)         (f_N + alpha·S_n + beta)
+
+    expr LHS = 0;
+    expr RHS1 = 0;
+    for (int i = 0; i < length(gsum_require); ++i) {
+        LHS = LHS * gsum_require[i];
+
+        expr tmp = 1;
+        for (int j = 0; j < length(gsum_require); ++j) {
+            if (j != i) {
+                tmp = tmp * gsum_require[j];
+            }
+        }
+        RHS1 = RHS1 + tmp;
+    }
+
+    expr RHS2a = LHS;
+    expr RHS2b = 0;
+    for (int i = 0; i < length(gsum_provide); ++i) {
+        LHS = LHS * gsum_provide[i];
+        RHS1 = RHS1 * gsum_provide[i];
+
+        expr tmp = 1;
+        for (int j = 0; j < length(gsum_provide); ++j) {
+            if (j != i) {
+                tmp = tmp * gsum_provide[j];
+            }
+        }
+        RHS2b = RHS2b + tmp;
+    }
+
+    expr RHS2 = RHS2a * RHS2b;
+    expr RHS = RHS1 - RHS2;
+
+    col fixed L1 = [1,0...];
+
+    (gsum - 'gsum) * LHS === RHS;
+    L1' * gsum === 0;
+}
+
+// It checks wheter there is some connection check without either provide or require
+private function check_connection_was_completed() {
+    for (int opid in air.std.connect.opids) {
+        if (proof.std.connect.`id${opid}`.require == 0) {
+            error(`Connection #${opid} defined without require`);
+        }
+        if (proof.std.connect.`id${opid}`.provide == 0) {
+            error(`Connection #${opid} defined without provide`);
+        }
+    }
+}

--- a/test/pil2/vadcop/std_connect.pil
+++ b/test/pil2/vadcop/std_connect.pil
@@ -21,11 +21,11 @@ private function init_coset_constants(int len) {
 
 // Two user interfaces
 
-// 1] Interface where the user uses the update() method to define the permutation "on the fly"
+// 1] Interface where the user uses either the update_one_cell() or the update_multiple_cells() method to define the permutation "on the fly"
 //    and when it is done, executes the connect() method to perform the connection argument.
 //    The user also needs to execute init() at the beginning.
 
-// TODO (Héctor): Throw an error if the calling path is not being called correctly?
+// TODO (Héctor): Throw an error if the calling path is not being called correctly? (as explained in the comment)
 
 function connection_init(int opid, expr cols[]) {
     check_opid_and_cols(opid, length(cols), 0, 0);
@@ -39,62 +39,65 @@ private function find_col_index(expr column) {
             return icol;
         }
     }
+
+    error(`Column ${column} has not been initialized in connect #${opid}`);
 }
 
-function connection_update_one(int opid, expr col1, int row1, expr col2, int row2) {
+function connection_update_one_cell(int opid, expr cols1[], int rows1[], expr cols2[], int rows2[]) {
     use proof.std.connect.`id${opid}`;
 
-    int col1_index = find_col_index(col1);
-    int col2_index = find_col_index(col2);
+    if (!(length(cols1) == length(rows1) == length(cols2) == length(rows2))) {
+        error(`The number of columns and rows of connect #${opid} must be the same`);
+    } else if (length(cols1) < 1) {
+        error(`The number of columns of connect #${opid} must be at least 1`);
+    }
 
-    expr tmp = SIDs[col1_index][row1]
-    SIDs[col1_index][row1] = SIDs[col2_index][row2];
-    SIDs[col2_index][row2] = tmp;
+    for (int i = 0; i < length(cols1); ++i) {
+            int col1_index = find_col_index(cols1[i]);
+            int col2_index = find_col_index(cols2[i]);
+
+            expr tmp = SIDs[col1_index][rows1[i]]
+            SIDs[col1_index][rows1[i]] = SIDs[col2_index][rows2[i]];
+            SIDs[col2_index][rows2[i]] = tmp;
+    }
 }
 
-function connection_update(int opid, expr col1, int rows1[], expr col2, int rows2[]) {
+function connection_update_multiple_cells(int opid, expr cols[], int rows[][]) {
     use proof.std.connect.`id${opid}`;
 
-    int len1 = length(rows1);
-    int len2 = length(rows2);
-
-    if (len1 == len2 == 1) {
-        connection_update_one(opid, col1, rows1[0], col2, rows2[0]);
-        return;
+    if (length(cols) != length(rows)) {
+        error(`The number of columns and rows of connect #${opid} must be the same`);
+    } else if (length(cols) < 1) {
+        error(`The number of columns of connect #${opid} must be at least 1`);
     }
 
-    int col1_index = find_col_index(col1);
-    int col2_index = find_col_index(col2);
+    expr SID_lasts[length(cols)];
+    // To avoid a double loop, we need the last element of the last column
+    int last_len = length(rows[length(rows)-1]);
+    int last_col_index = find_col_index(cols[length(cols)-1]);
+    SID_lasts[length(cols)-1] = SIDs[last_col_index][rows[length(rows)-1][last_len-1]];
 
-    expr SID1 = SIDs[col1_index];
-    expr SID2 = SIDs[col2_index];
+    for (int i = 0; i < length(cols); ++i) {
+        int len = length(rows[i]);
 
-    expr SID1_last = SID1[rows1[len1-1]];
-    expr SID2_last = SID2[rows2[len2-1]];
+        int col_index = find_col_index(cols[i]);
+        expr SID = SIDs[col_index];
+        SID_lasts[i] = SID[rows[i][len-1]];
 
-    if (len1 >= 2) {
-        for (int icol = len1 - 2; icol >= 0; --icol) {
-            int row1 = rows1[icol];
-            int row2 = rows1[icol+1];
-
-            SID1[row2] = SID1[row1]
+        if (len == 1) {
+            continue;
         }
-    }
 
-    if (len2 >= 2) {
-        for (int icol = len2 - 2; icol >= 0; --icol) {
-            int row1 = rows2[icol];
-            int row2 = rows2[icol+1];
+        for (int j = len - 2; j >= 0; --j) {
+            int row1 = rows[i][j];
+            int row2 = rows[i][j+1];
 
-            SID2[row2] = SID2[row1]
+            SID[row2] = SID[row1]
         }
-    }
 
-    SID1[0] = SID2_last;
-    SID2[0] = SID1_last;
+        SID[rows[i][0]] = SID_last[i-1];
+    }
 }
-
-// TODO (Héctor): Add a generalisation where more than two columns can be chosen
 
 function connection_connect(int opid) {
     use proof.std.connect.`id${opid}`;

--- a/test/pil2/vadcop/std_mset_lookup_range.pil
+++ b/test/pil2/vadcop/std_mset_lookup_range.pil
@@ -7,6 +7,14 @@ private function init_challenges() {
     }
 }
 
+function multiset_require(int opid, expr cols[]) {
+    piop_update(0, opid, 1, cols);
+}
+
+function multiset_provide(int opid, expr cols[]) {
+    piop_update(1, opid, 1, cols);
+}
+
 function multiset_require(int opid, expr sel, expr cols[]) {
     piop_update(0, opid, sel, cols);
 }
@@ -15,12 +23,63 @@ function multiset_provide(int opid, expr sel, expr cols[]) {
     piop_update(1, opid, sel, cols);
 }
 
+function lookup_require(int opid, expr cols[]) {
+    piop_update(0, opid, 1, cols);
+}
+
+function lookup_provide(int opid, expr cols[]) {
+    piop_update(1, opid, 1, cols);
+}
+
 function lookup_require(int opid, expr sel, expr cols[]) {
     piop_update(0, opid, sel, cols);
 }
 
 function lookup_provide(int opid, expr sel, expr cols[]) {
     piop_update(1, opid, sel, cols);
+}
+
+// To support vector range checks, we would need to compute a table of all permutations of the range [min,max-1].
+function range_check(int opid, expr cols[], int min, int max) {
+    for (int i = 0; i < length(cols); ++i) {
+        piop_update(0, opid, 1, cols[i]);
+    }
+    
+    col fixed RANGE = [min,min+1,..+..,max-1]; // QUESTION: Does this still work if max - min > N?
+    col witness mul_count = compute_multiplicity(cols, RANGE);
+    piop_update(1, opid, mul_count, RANGE);
+}
+
+function range_check(int opid, expr sels[], expr cols[], int min, int max) {
+    for (int i = 0; i < length(cols); ++i) {
+        piop_update(0, opid, sels[i], cols[i]);
+    }
+    
+    col fixed RANGE = [min,min+1,..+..,max-1];
+    col witness mul_count = compute_multiplicity(cols, RANGE);
+    piop_update(1, opid, mul_count, RANGE);
+}
+
+// QUESTION: Can the following O(n³) algorithm be implemented faster?
+/**
+ * Given columns C₀,...,Cₙ₋₁, and a range, computes the multiplicity counter:
+        · mul_count[i] = Σⱼ |{k : Cⱼ[k] = range[i]}|
+ * @param cols
+ * @param range
+ */
+private function compute_multiplicity(expr cols[], expr range) {
+    expr mul_count[length(range)] = 0; // [0,0,...,0]
+    for (int i = 0; i < length(range); ++i) {
+        for (int j = 0; j < length(cols); ++j) {
+            for (int k = 0; k < length(cols[j]); ++k) {
+                if (cols[j][k] == range[i]) {
+                    ++mul_count[i];
+                }
+            }
+        }
+    }
+    // Note: We do not need to normalize the result, since a range has no repeated elements.
+    return mul_count;
 }
 
 /**
@@ -49,11 +108,9 @@ private function check_opid_and_cols(int opid, int cols_count, int provide) {
 
     container air.std.piop {
         // FIX: dynamic arrays not ready
-        int gsum_require_count = 0;
-        expr gsum_require_mul_count[100];
+        expr gsum_require_sel[100];
         expr gsum_require[100];
-        int gsum_provide_count = 0;
-        expr gsum_provide_mul_count[100];
+        expr gsum_provide_sel[100];
         expr gsum_provide[100];
     }
 
@@ -86,7 +143,7 @@ private function check_opid_and_cols(int opid, int cols_count, int provide) {
  * @param cols columns of the PIOP
  * @return [opid + C₁·α + C₂·α² + ... + Cₙ·αⁿ] + β
  */
-function compress_cols(int opid, expr cols[]): expr {
+private function compress_cols(int opid, expr cols[]): expr {
     expr cols_compressed = 0;
     for (int icol = length(cols) - 1; icol >= 0; --icol) {
         cols_compressed = (cols_compressed + cols[icol]) * std_alpha;
@@ -101,10 +158,10 @@ function compress_cols(int opid, expr cols[]): expr {
  * Given columns C₀,...,Cₙ₋₁, and multiplicity counter M, it 1] defines the constraints at the air level, 2] updates the values at the subproof level, and 3] updates the constraints at the proof level.
  * @param provide boolean indicating if updating a provide or a require
  * @param opid (unique) identifier of the PIOP
- * @param mul_count multiplicity counter of the PIOP
+ * @param sel selector of the PIOP
  * @param cols columns of the PIOP
  */
-function piop_update(int provide, int opid, expr mul_count, expr cols[]) {
+private function piop_update(int provide, int opid, expr sel, expr cols[]) {
     // verify if correct opid and cols
     check_opid_and_cols(opid, length(cols), provide);
 
@@ -116,55 +173,47 @@ function piop_update(int provide, int opid, expr mul_count, expr cols[]) {
     use air.std.piop;
     if (provide) {
         // adding all sums of provide called in this air
-        gsum_provide_mul_count[gsum_provide_count] = mul_count;
-        gsum_provide[gsum_provide_count] = cols_compressed;
-        ++gsum_provide_count;
+        gsum_provide_sel[] = sel;
+        gsum_provide[] = cols_compressed;
     } else {
         // adding all sums of require called in this air
-        gsum_require_mul_count[gsum_require_count] = mul_count;
-        gsum_require[gsum_require_count] = cols_compressed;
-        ++gsum_require_count;
+        gsum_require_sel[] = sel;
+        gsum_require[] = cols_compressed;
     }
 
-    // 0] look for repeated provide/require's and, if so, optimize
-    on final air PIOP_batch();
+    // 1] computes the multiplicity counter for lookups and range checks
+    on final air compute_multiplicity_lookup_range();
 
-    // 1] define constraints at the air level
+    // 2] look for repeated provide/require's in both lookups and range checks and, if found, optimize
+    on final air lookup_range_provide_batch();
+
+    // 3] define constraints at the air level
     on final air PIOP_air();
 
-    // 2] update values at the subproof level
+    // 4] update values at the subproof level
     on final subproof PIOP_subproof();
 
-    // 3] update constraints at the proof level
+    // 5] update constraints at the proof level
     on final proof PIOP_proof();
 }
 
-// Can the following O(n²) algorithm be implemented faster?
-private function PIOP_batch() {
+// QUESTION: Can the following O(n²) algorithm be implemented faster?
+// Given the provides, it "merges" the repeated ones through their associated multiplicity counters.
+private function lookup_range_provide_batch() {
     use air.std.piop;
 
-    // int len = length(gsum_provide);
-    int len = gsum_provide_count;
+    int len = length(gsum_provide);
 
     for (int i = 0; i < len; ++i) {
         for (int j = 0; j < len; ++j) {
+            // It two provides are the same, add their multiplicity counters to one and remove the other
             if (i != j && gsum_provide[i] == gsum_provide[j]) {
-                gsum_provide_mul_count[i] = gsum_provide_mul_count[i] + gsum_provide_mul_count[j];
-                gsum_provide_mul_count[j] = gsum_provide_mul_count[len-1];
-                // gsum_provide_mul_count.pop(); // QUESTION: Is array pop implemented?
-            }
-        }
-    }
+                gsum_provide_sel[i] = gsum_provide_sel[i] + gsum_provide_sel[j];
 
-    // len = length(gsum_require);
-    len = gsum_require_count;
-
-    for (int i = 0; i < len; ++i) {
-        for (int j = 0; j < len; ++j) {
-            if (i != j && gsum_require[i] == gsum_require[j]) {
-                gsum_require_mul_count[i] = gsum_require_mul_count[i] + gsum_require_mul_count[j];
-                gsum_require_mul_count[j] = gsum_require_mul_count[len-1];
-                // gsum_require_mul_count.pop();
+                gsum_provide[j] = gsum_provide[len-1];
+                gsum_provide_sel[j] = gsum_provide_sel[len-1];
+                gsum_provide.pop(); // QUESTION: Will array pop be implemented?
+                gsum_provide_sel.pop(); 
             }
         }
     }
@@ -173,7 +222,7 @@ private function PIOP_batch() {
 private function PIOP_air() {
     use air.std.piop;
 
-    col witness stage(3) gsum;
+    col witness stage(2) gsum;
 
     //                                mt1       mt2       mt3       mf1       mf2       mf3
     //  gsum === 'gsum * (1 - L1) + ------- + ------- + ------- - ------- - ------- - -------
@@ -183,33 +232,25 @@ private function PIOP_air() {
 
     expr LHS = 1;
     expr RHS1 = 0;
-    // for (int i = 0; i < length(gsum_provide); ++i) {
-    for (int i = 0; i < gsum_provide_count; ++i) {
+    for (int i = 0; i < length(gsum_provide); ++i) {
         LHS = LHS * gsum_provide[i];
 
-        expr tmp = gsum_provide_mul_count[i];
-        // for (int j = 0; j < length(gsum_provide); ++j) {
-        for (int j = 0; j < gsum_provide_count; ++j) {
-            // if (j == i) continue;
-            if (j != i) {
-                tmp = tmp * gsum_provide[j];
-            }
+        expr tmp = gsum_provide_sel[i];
+        for (int j = 0; j < length(gsum_provide); ++j) {
+            if (j != i) tmp = tmp * gsum_provide[j];
         }
         RHS1 = RHS1 + tmp;
     }
 
     expr RHS2a = LHS;
     expr RHS2b = 0;
-    // for (int i = 0; i < length(gsum_require); ++i) {
-    for (int i = 0; i < gsum_require_count; ++i) {
+    for (int i = 0; i < length(gsum_require); ++i) {
         LHS = LHS * gsum_require[i];
         RHS1 = RHS1 * gsum_require[i];
 
-        expr tmp = gsum_require_mul_count[i];
-        // for (int j = 0; j < length(gsum_require); ++j) {
-        for (int j = 0; j < gsum_require_count; ++j) {
-            if (j == i) continue;
-            tmp = tmp * gsum_require[j];
+        expr tmp = gsum_require_sel[i];
+        for (int j = 0; j < length(gsum_require); ++j) {
+            if (j != i) tmp = tmp * gsum_require[j];
         }
         RHS2b = RHS2b + tmp;
     }

--- a/test/pil2/vadcop/std_mset_lookup_range.pil
+++ b/test/pil2/vadcop/std_mset_lookup_range.pil
@@ -8,56 +8,58 @@ private function init_challenges() {
 }
 
 function multiset_require(int opid, expr cols[]) {
-    piop_update(0, opid, 1, cols);
+    piop_update(0, 0, opid, 1, cols);
 }
 
 function multiset_provide(int opid, expr cols[]) {
-    piop_update(1, opid, 1, cols);
+    piop_update(1, 0, opid, 1, cols);
 }
 
 function multiset_require(int opid, expr sel, expr cols[]) {
-    piop_update(0, opid, sel, cols);
+    piop_update(0, 0, opid, sel, cols);
 }
 
 function multiset_provide(int opid, expr sel, expr cols[]) {
-    piop_update(1, opid, sel, cols);
+    piop_update(1, 0, opid, sel, cols);
 }
 
 function lookup_require(int opid, expr cols[]) {
-    piop_update(0, opid, 1, cols);
+    piop_update(0, 1, opid, 1, cols);
 }
 
 function lookup_provide(int opid, expr cols[]) {
-    piop_update(1, opid, 1, cols);
+    piop_update(1, 1, opid, 1, cols);
 }
 
-function lookup_require(int opid, expr sel, expr cols[]) {
-    piop_update(0, opid, sel, cols);
+// Right now, we assume that the user provides the multiplicity counter.
+// However, we could let the user to only give us the selector and the columns, and we compute the multiplicity counter.
+function lookup_require(int opid, expr mul_count, expr cols[]) {
+    piop_update(0, 1, opid, mul_count, cols);
 }
 
-function lookup_provide(int opid, expr sel, expr cols[]) {
-    piop_update(1, opid, sel, cols);
+function lookup_provide(int opid, expr mul_count, expr cols[]) {
+    piop_update(1, 1, opid, mul_count, cols);
 }
 
 // To support vector range checks, we would need to compute a table of all permutations of the range [min,max-1].
 function range_check(int opid, expr cols[], int min, int max) {
     for (int i = 0; i < length(cols); ++i) {
-        piop_update(0, opid, 1, cols[i]);
+        piop_update(0, 1, opid, 1, cols[i]);
     }
     
     col fixed RANGE = [min,min+1,..+..,max-1]; // QUESTION: Does this still work if max - min > N?
-    col witness mul_count = compute_multiplicity(cols, RANGE);
-    piop_update(1, opid, mul_count, RANGE);
+    col witness mul_count = compute_multiplicities(cols, RANGE);
+    piop_update(1, 1, opid, mul_count, RANGE);
 }
 
 function range_check(int opid, expr sels[], expr cols[], int min, int max) {
     for (int i = 0; i < length(cols); ++i) {
-        piop_update(0, opid, sels[i], cols[i]);
+        piop_update(0, 1, opid, sels[i], cols[i]);
     }
     
     col fixed RANGE = [min,min+1,..+..,max-1];
-    col witness mul_count = compute_multiplicity(cols, RANGE);
-    piop_update(1, opid, mul_count, RANGE);
+    col witness mul_count = compute_multiplicities(cols, RANGE);
+    piop_update(1, 1, opid, mul_count, RANGE);
 }
 
 // QUESTION: Can the following O(n³) algorithm be implemented faster?
@@ -67,7 +69,7 @@ function range_check(int opid, expr sels[], expr cols[], int min, int max) {
  * @param cols
  * @param range
  */
-private function compute_multiplicity(expr cols[], expr range) {
+private function compute_multiplicities(expr cols[], expr range) {
     expr mul_count[length(range)] = 0; // [0,0,...,0]
     for (int i = 0; i < length(range); ++i) {
         for (int j = 0; j < length(cols); ++j) {
@@ -88,7 +90,7 @@ private function compute_multiplicity(expr cols[], expr range) {
  * @param cols_count number of columns of the PIOP check
  * @param provide 1 if provide, 0 if require
  */
-private function check_opid_and_cols(int opid, int cols_count, int provide) {
+private function check_opid_and_cols(int provide, int type, int opid, int cols_count) {
 
     if (cols_count < 1) {
         error(`The number of columns of PIOP #${opid} must be at least 1`);
@@ -110,6 +112,7 @@ private function check_opid_and_cols(int opid, int cols_count, int provide) {
         // FIX: dynamic arrays not ready
         expr gsum_require_sel[100];
         expr gsum_require[100];
+        expr gsum_provide_type[100];
         expr gsum_provide_sel[100];
         expr gsum_provide[100];
     }
@@ -157,13 +160,14 @@ private function compress_cols(int opid, expr cols[]): expr {
 /**
  * Given columns C₀,...,Cₙ₋₁, and multiplicity counter M, it 1] defines the constraints at the air level, 2] updates the values at the subproof level, and 3] updates the constraints at the proof level.
  * @param provide boolean indicating if updating a provide or a require
+ * @param type if 1, it is a lookup or a range check; if 0, it is a multiset
  * @param opid (unique) identifier of the PIOP
  * @param sel selector of the PIOP
  * @param cols columns of the PIOP
  */
-private function piop_update(int provide, int opid, expr sel, expr cols[]) {
+private function piop_update(int provide, int type, int opid, expr sel, expr cols[]) {
     // verify if correct opid and cols
-    check_opid_and_cols(opid, length(cols), provide);
+    check_opid_and_cols(provide, type, opid, length(cols));
 
     init_challenges();
 
@@ -173,6 +177,7 @@ private function piop_update(int provide, int opid, expr sel, expr cols[]) {
     use air.std.piop;
     if (provide) {
         // adding all sums of provide called in this air
+        gasum_provide_type[] = type;
         gsum_provide_sel[] = sel;
         gsum_provide[] = cols_compressed;
     } else {
@@ -181,19 +186,20 @@ private function piop_update(int provide, int opid, expr sel, expr cols[]) {
         gsum_require[] = cols_compressed;
     }
 
-    // 1] computes the multiplicity counter for lookups and range checks
-    on final air compute_multiplicity_lookup_range();
+    // QUESTION: Should the user provide the multiplicity counter? Or we should compute it?
+    // 0] computes the multiplicity counter for lookups and range checks
+    // on final air compute_multiplicities_lookup_range();
 
-    // 2] look for repeated provide/require's in both lookups and range checks and, if found, optimize
+    // 1] look for repeated provide/require's in both lookups and range checks and, if found, optimize
     on final air lookup_range_provide_batch();
 
-    // 3] define constraints at the air level
+    // 2] define constraints at the air level
     on final air PIOP_air();
 
-    // 4] update values at the subproof level
+    // 3] update values at the subproof level
     on final subproof PIOP_subproof();
 
-    // 5] update constraints at the proof level
+    // 4] update constraints at the proof level
     on final proof PIOP_proof();
 }
 
@@ -206,8 +212,9 @@ private function lookup_range_provide_batch() {
 
     for (int i = 0; i < len; ++i) {
         for (int j = 0; j < len; ++j) {
+            if (i == j) continue;
             // It two provides are the same, add their multiplicity counters to one and remove the other
-            if (i != j && gsum_provide[i] == gsum_provide[j]) {
+            if (gsum_provide[j] == gsum_provide[i] && gsum_provide_type[j] == 1) {
                 gsum_provide_sel[i] = gsum_provide_sel[i] + gsum_provide_sel[j];
 
                 gsum_provide[j] = gsum_provide[len-1];

--- a/test/pil2/vadcop/std_prod.pil
+++ b/test/pil2/vadcop/std_prod.pil
@@ -90,7 +90,7 @@ private function check_multiset_opid_and_cols(int opid, int cols_count, int prov
  * @param cols array of columns of the argument
  * @return S·([opid + C₁·α + C₂·α² + ... + Cₙ·αⁿ] + β - 1) + 1
  */
-function multiset_prepare_cols(int opid, expr sel, expr cols[]): expr {
+private function multiset_prepare_cols(int opid, expr sel, expr cols[]): expr {
     expr cols_compressed = 0;
     for (int icol = length(cols) - 1; icol >= 0; --icol) {
         cols_compressed = (cols_compressed + cols[icol]) * std_alpha;
@@ -113,7 +113,7 @@ function multiset_prepare_cols(int opid, expr sel, expr cols[]): expr {
  * @param sel selector of the argument
  * @param cols columns of the argument
  */
-function multiset_update(int provide, int opid, expr sel, expr cols[]) {
+private function multiset_update(int provide, int opid, expr sel, expr cols[]) {
     // verify if correct opid and cols
     check_multiset_opid_and_cols(opid, length(cols), provide);
 
@@ -282,7 +282,7 @@ private function check_lookup_opid_and_cols(int opid, int cols_count, int provid
  * @param cols columns of the argument
  * @return S·[opid + C₁·α + C₂·α² + ... + Cₙ·αⁿ]
  */
-function lookup_prepare_cols (int opid, expr sel, expr cols[]): expr {
+private function lookup_prepare_cols (int opid, expr sel, expr cols[]): expr {
     expr cols_compressed = 0;
     for (int icol = length(cols) - 1; icol >= 0; --icol) {
         cols_compressed = (cols_compressed + cols[icol]) * std_alpha;
@@ -305,7 +305,7 @@ function lookup_prepare_cols (int opid, expr sel, expr cols[]): expr {
  * @param sel selector of the argument
  * @param cols columns of the argument
  */
-function lookup_update_provide(int opid, expr selP, expr colsP[]) {
+private function lookup_update_provide(int opid, expr selP, expr colsP[]) {
     // verify if correct opid and cols
     check_lookup_opid_and_cols(opid, length(colsP), 1);
 
@@ -325,7 +325,7 @@ function lookup_update_provide(int opid, expr selP, expr colsP[]) {
     // define constraints at the air level
     on final air lookup_air();
 }
-function lookup_update_require(int opid, expr selR, expr colsR[]) {
+private function lookup_update_require(int opid, expr selR, expr colsR[]) {
     // verify if correct opid and cols
     check_lookup_opid_and_cols(opid, length(colsR), 0);
 
@@ -353,7 +353,7 @@ private function lookup_air() {
 
     use air.std.lookup;
 
-    @lookup_check {h1: h1, h2: h2, colsT: gprod_provide, colsF: gprod_require, gprod};
+    @lookup_check {h1: h1, h2: h2, colsF: gprod_require, colsT: gprod_provide, prod: gprod};
 
     // Define h1,h2 polynomials
     col witness h1 stage(2);
@@ -506,7 +506,7 @@ private function check_connection_opid_and_cols(int opid, int cols_count, int pr
  * @param sel selector of the argument
  * @param cols columns of the argument
  */
-function connection_update_provide(int opid, expr colsP[]) {
+private function connection_update_provide(int opid, expr colsP[]) {
     // verify if correct opid and cols
     check_connection_opid_and_cols(opid, length(colsP), 1);
 
@@ -523,7 +523,8 @@ function connection_update_provide(int opid, expr colsP[]) {
     // define constraints at the air level
     on final air connection_air();
 }
-function connection_update_require(int opid, expr colsR[]) {
+
+private function connection_update_require(int opid, expr colsR[]) {
     // verify if correct opid and cols
     check_connection_opid_and_cols(opid, length(colsR), 1);
 

--- a/test/pil2/vadcop/std_sum.pil
+++ b/test/pil2/vadcop/std_sum.pil
@@ -187,14 +187,15 @@ private function PIOP_air() {
     for (int i = 0; i < gsum_provide_count; ++i) {
         LHS = LHS * gsum_provide[i];
 
-        RHS1 = RHS1 + gsum_provide_mul_count[i];
+        expr tmp = gsum_provide_mul_count[i];
         // for (int j = 0; j < length(gsum_provide); ++j) {
         for (int j = 0; j < gsum_provide_count; ++j) {
             // if (j == i) continue;
             if (j != i) {
-                RHS1 = RHS1 * gsum_provide[j];
+                tmp = tmp * gsum_provide[j];
             }
         }
+        RHS1 = RHS1 + tmp;
     }
 
     expr RHS2a = LHS;
@@ -204,12 +205,13 @@ private function PIOP_air() {
         LHS = LHS * gsum_require[i];
         RHS1 = RHS1 * gsum_require[i];
 
-        RHS2b = RHS2b + gsum_require_mul_count[i];
+        expr tmp = gsum_require_mul_count[i];
         // for (int j = 0; j < length(gsum_require); ++j) {
         for (int j = 0; j < gsum_require_count; ++j) {
             if (j == i) continue;
-            RHS2b = RHS2b * gsum_require[j];
+            tmp = tmp * gsum_require[j];
         }
+        RHS2b = RHS2b + tmp;
     }
 
     expr RHS2 = RHS2a * RHS2b;

--- a/test/pil2/vadcop/std_sum.pil
+++ b/test/pil2/vadcop/std_sum.pil
@@ -29,7 +29,7 @@ function lookup_provide(int opid, expr sel, expr cols[]) {
  * @param cols_count number of columns of the PIOP check
  * @param provide 1 if provide, 0 if require
  */
-private function check_id_and_cols(int opid, int cols_count, int provide) {
+private function check_opid_and_cols(int opid, int cols_count, int provide) {
 
     if (cols_count < 1) {
         error(`The number of columns of PIOP #${opid} must be at least 1`);
@@ -106,7 +106,7 @@ function compress_cols(int opid, expr cols[]): expr {
  */
 function piop_update(int provide, int opid, expr mul_count, expr cols[]) {
     // verify if correct opid and cols
-    check_id_and_cols(opid, length(cols), provide);
+    check_opid_and_cols(opid, length(cols), provide);
 
     init_challenges();
 

--- a/tools/main_pilverifier.js
+++ b/tools/main_pilverifier.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const version = require("../package").version;
+const tty = require('tty');
+
+const { importPolynomials } = require("./binfiles.js");
+
+const { compile, verifyPil, newConstantPolsArray, newCommitPolsArray } = require("../index");
+
+const { F1Field } = require("ffjavascript");
+
+const argv = require("yargs")
+    .version(version)
+    .usage("main_pilverifier.js <commit.bin> -p <input.pil> [-j <input_pil.json>] -c <constant.bin> [-u <publics.json>]")
+    .alias("p", "pil")
+    .alias("j", "pil-json")
+    .alias("c", "constant")
+    .alias("P", "config")
+    .alias("v", "verbose")
+    .alias("u", "publics")
+    .argv;
+
+async function run() {
+
+    const F = new F1Field("0xFFFFFFFF00000001");
+
+    let commitFile;
+    if (argv._.length == 0) {
+        console.log("You need to specify a commit file file file");
+        process.exit(1);
+    } else if (typeof(argv.pil) === "string" && typeof(argv.pilJson) === "string") {
+        console.log("The options '-p' and '-j' exclude each other.");
+        process.exit(1);
+    } else if (argv._.length == 1) {
+        commitFile = argv._[0];
+    } else {
+        console.log("Only one commit file at a time is permited");
+        process.exit(1);
+    }
+
+    const publics = typeof(argv.publics) === "string" ?  JSON.parse(fs.readFileSync(argv.publics.trim())) : false;
+    const constantFile = typeof(argv.constant) === "string" ?  argv.constant.trim() : "constant.bin";
+
+    const config = typeof(argv.config) === "string" ? JSON.parse(fs.readFileSync(argv.config.trim())) : {};
+
+    if (argv.verbose) {
+        config.verbose = true;
+        if (typeof config.color === 'undefined') {
+            config.color = tty.isatty(process.stdout.fd);
+        }
+    }
+
+    let pil;
+    if (typeof(argv.pilJson) === "string") {
+        pil = JSON.parse(fs.readFileSync(argv.pilJson.trim()));
+    } else {
+        const pilFile = typeof(argv.pil) === "string" ?  argv.pil.trim() : "main.pil";
+        pil = await compile(F, pilFile, null, config);
+    }
+
+    const n = pil.references[Object.keys(pil.references)[0]].polDeg;
+
+    const constPols =  newConstantPolsArray(pil);
+    const cmPols =  newCommitPolsArray(pil);
+
+    await constPols.loadFromFile(constantFile);
+    await cmPols.loadFromFile(commitFile);
+
+    const res = await verifyPil(F, pil, cmPols, constPols, {publics});
+
+    if (res.length != 0) {
+        console.log("Pil does not pass");
+        for (let i=0; i<res.length; i++) {
+            console.log(res[i]);
+        }
+    } else {
+        console.log("PIL OK!!")
+    }
+}
+
+run().then(()=> {
+    process.exit(0);
+}, (err) => {
+    console.log(err.message);
+    console.log(err.stack);
+    process.exit(1);
+});
+
+exports.log2 = function log2( V )
+{
+    return( ( ( V & 0xFFFF0000 ) !== 0 ? ( V &= 0xFFFF0000, 16 ) : 0 ) | ( ( V & 0xFF00FF00 ) !== 0 ? ( V &= 0xFF00FF00, 8 ) : 0 ) | ( ( V & 0xF0F0F0F0 ) !== 0 ? ( V &= 0xF0F0F0F0, 4 ) : 0 ) | ( ( V & 0xCCCCCCCC ) !== 0 ? ( V &= 0xCCCCCCCC, 2 ) : 0 ) | ( ( V & 0xAAAAAAAA ) !== 0 ) );
+}

--- a/tools/pil_verifier.js
+++ b/tools/pil_verifier.js
@@ -1,0 +1,394 @@
+const { log2, getKs, getRoots } = require("./utils.js");
+
+module.exports = async function verifyPil(F, pil, wtnsCols, fixCols, config = {}) {
+
+    const res = [];
+
+    const refWtns = {};
+    const refFix = {};
+    const refIm = {};
+    for (let k of Object.keys(pil.references)) {
+        const r  = pil.references[k];
+        r.name = k;
+        if (r.type == "cmP") {
+            refWtns[r.id] =r;
+        } else if (r.type == "constP") {
+            refFix[r.id] = r;
+        } else if (r.type == "imP") {
+            refIm[r.id] = r;
+        } else {
+            throw new Error("Reference type not handled: " + r.type);
+        }
+    }
+
+    const pols = {
+        cm: [],
+        exps:[],
+        const: [],
+        publics: []
+    };
+
+    const N = wtnsCols.$$n;
+
+    for (let i=0; i<pil.nCommitments; i++) pols.cm[i] = {};
+    for (let i=0; i<pil.expressions.length; i++) pols.exps[i] = {};
+    for (let i=0; i<pil.nConstants; i++) pols.const[i] = {};
+
+// 1.- Prepare commited polynomials.
+    for (let i=0; i<wtnsCols.$$nPols; i++) {
+        pols.cm[i].v_n = wtnsCols.$$array[i];
+    }
+
+    for (let i=0; i<fixCols.$$nPols; i++) {
+        pols.const[i].v_n = fixCols.$$array[i];
+    }
+
+    for (let i=0; i<pil.publics.length; i++) {
+
+        if (config.publics) {
+            pols.publics[i] = BigInt(config.publics[i]);
+            console.log(`loading public[${i+1}/${pil.publics.length}] = ${pols.publics[i]}`);
+        } else {
+            console.log(`preparing public ${i+1}/${pil.publics.length}`);
+            if (pil.publics[i].polType == "cmP") {
+                pols.publics[i] = pols.cm[pil.publics[i].polId].v_n[pil.publics[i].idx];
+            } else if (pil.publics[i].polType == "imP") {
+                await calculateExpression(pil.publics[i].polId);
+                pols.publics[i] = pols.exps[pil.publics[i].polId].v_n[pil.publics[i].idx];
+                delete pols.exps[pil.publics[i].polId].v_n;
+            } else {
+                throw new Error(`Invalid public type: ${polType.type}`);
+            }
+        }
+    }
+
+    for (let i=0; i<pil.connectionIdentities.length; i++) {
+        console.log(`Checking connectionIdentities ${i+1}/${pil.connectionIdentities.length}`);
+        ci = pil.connectionIdentities[i];
+        for (let j=0; j<ci.pols.length; j++) {
+            await calculateExpression(ci.pols[j]);
+        }
+        for (let j=0; j<ci.connections.length; j++) {
+            await calculateExpression(ci.connections[j]);
+        }
+
+        console.log("start generating cm");
+        let cm = getConnectionMap(F, N, ci.pols.length);
+
+        for (let j=0; j<ci.pols.length; j++) {
+            for (let k=0; k<N; k++) {
+                if (k%10000 == 0) console.log(`${k+1}/${N}`);
+                const v1 = pols.exps[ci.pols[j]].v_n[k];
+
+                const a = pols.exps[ci.connections[j]].v_n[k]
+                const a1 = Number(a >> 52n);
+                const a2 = Number((a >> 40n)&0xFFFn );
+                const a3 = Number(a&0xFFFFFFFFFFn );
+
+
+                const [cp, cw] = cm[a1][a2][a3];
+                if (typeof cp == "undefined") {
+                    res.push(`${ci.fileName}:${pil.connectionIdentities[i].line}: invalid copy value w=${j},${k} val=${F.toString(v1)} `);
+                    console.log(res[res.length-1]);
+                }
+                const v2 = pols.exps[ci.pols[cp]].v_n[cw];
+
+                if (!F.eq(v1, v2)) {
+                    res.push(`${ci.fileName}:${pil.connectionIdentities[i].line}: connection does not match p1=${j} w1=${k} p2=${cp}, w2=${cw} val= ${F.toString(v1)} != ${F.toString(v2)}`);
+                    console.log(res[res.length-1]);
+                    k=N;
+                    j=ci.pols.length;
+                }
+            }
+        }
+
+        for (let j=0; j<ci.pols.length; j++) {
+            delete pols.exps[ci.pols[j]].v_n;
+        }
+        for (let j=0; j<ci.connections.length; j++) {
+            delete pols.exps[ci.connections[j]].v_n;
+        }
+
+    }
+
+    for (let i=0; i<pil.plookupIdentities.length; i++) {
+        console.log(`Checking plookupIdentities ${i+1}/${pil.plookupIdentities.length}`);
+        const pi =pil.plookupIdentities[i];
+
+        for (let j=0; j<pi.t.length; j++) {
+            await calculateExpression(pi.t[j]);
+        }
+        if (pi.selT !== null) {
+            await calculateExpression(pi.selT);
+        }
+        for (let j=0; j<pi.f.length; j++) {
+            await calculateExpression(pi.f[j]);
+        }
+        if (pi.selF !== null) {
+            await calculateExpression(pi.selF);
+        }
+
+        let t = {};
+        for (let j=0; j<N; j++) {
+            const selTValue = pi.selT == null ? F.one : pols.exps[pi.selT].v_n[j];
+            if (!F.isZero(selTValue)) {
+                const vals = []
+                for (let k=0; k<pi.t.length; k++) {
+                    vals.push(F.toString(pols.exps[pi.t[k]].v_n[j]));
+                }
+                const v = selTValue + ':' + vals.join(",");
+                t[v] = true;
+            }
+        }
+
+        for (let j=0; j<N; j++) {
+            const selFValue = pi.selF == null ? F.one : pols.exps[pi.selF].v_n[j];
+            if (!F.isZero(selFValue)) {
+                const vals = []
+                for (let k=0; k<pi.f.length; k++) {
+                    vals.push(F.toString(pols.exps[pi.f[k]].v_n[j]));
+                }
+                const v = selFValue + ':' + vals.join(",");
+                if (!t[v]) {
+                    res.push(`${pil.plookupIdentities[i].fileName}:${pil.plookupIdentities[i].line}:  plookup not found w=${j} values: ${v}`);
+                    console.log(res[res.length-1]);
+                    if (!config.continueOnError) j=N;  // Do not continue checking
+                }
+            }
+        }
+
+        for (let j=0; j<pi.t.length; j++) {
+            delete pols.exps[pi.t[j]].v_n;
+        }
+        if (pi.selT !== null) {
+            delete pols.exps[pi.selT].v_n;
+        }
+        for (let j=0; j<pi.f.length; j++) {
+            delete pols.exps[pi.f[j]].v_n;
+        }
+        if (pi.selF !== null) {
+            delete pols.exps[pi.selF].v_n;
+        }
+
+    }
+
+
+    for (let i=0; i<pil.permutationIdentities.length; i++) {
+        console.log(`Checking permutationIdentities ${i+1}/${pil.permutationIdentities.length}`);
+
+        const pi =pil.permutationIdentities[i];
+
+        for (let j=0; j<pi.t.length; j++) {
+            await calculateExpression(pi.t[j]);
+        }
+        if (pi.selT !== null) {
+            await calculateExpression(pi.selT);
+        }
+        for (let j=0; j<pi.f.length; j++) {
+            await calculateExpression(pi.f[j]);
+        }
+        if (pi.selF !== null) {
+            await calculateExpression(pi.selF);
+        }
+
+        let t = {};
+        for (let j=0; j<N; j++) {
+            const selTValue = pi.selT == null ? F.one : pols.exps[pi.selT].v_n[j];
+            if (!F.isZero(selTValue)) {
+                const vals = []
+                for (let k=0; k<pi.t.length; k++) {
+                    vals.push(F.toString(pols.exps[pi.t[k]].v_n[j]));
+                }
+                const v = selTValue + ':' + vals.join(",");
+                t[v] = (t[v] || 0) + 1;
+            }
+        }
+
+        let showRemainingErrors = true;
+        for (let j=0; j<N; j++) {
+            const selFValue = pi.selF == null ? F.one : pols.exps[pi.selF].v_n[j];
+            if (!F.isZero(selFValue)) {
+                const vals = []
+                for (let k=0; k<pi.f.length; k++) {
+                    vals.push(F.toString(pols.exps[pi.f[k]].v_n[j]));
+                }
+                const v = selFValue + ':' + vals.join(",");
+                const found = t[v] ?? false;
+                if (!t[v]) {
+                    res.push(`${pi.fileName}:${pi.line}:  permutation not `+(found === 0 ? 'enought ':'')+`found w=${j} values: ${v}`);
+                    console.log(res[res.length-1]);
+                    if (!config.continueOnError) {
+                        j=N;  // Do not continue checking
+                        showRemainingErrors = false;
+                    }
+                }
+                else {
+                    t[v] -= 1;
+                }
+            }
+        }
+        if (showRemainingErrors) {
+            for (const v in t) {
+                if (t[v] === 0) continue;
+                res.push(`${pi.fileName}:${pi.line}:  permutation failed. Remaining ${t[v]} values: ${v}`);
+                console.log(res[res.length-1]);
+            }
+        }
+
+        for (let j=0; j<pi.t.length; j++) {
+            delete pols.exps[pi.t[j]].v_n;
+        }
+        if (pi.selT !== null) {
+            delete pols.exps[pi.selT].v_n;
+        }
+        for (let j=0; j<pi.f.length; j++) {
+            delete pols.exps[pi.f[j]].v_n;
+        }
+        if (pi.selF !== null) {
+            delete pols.exps[pi.selF].v_n;
+        }
+
+    }
+
+    for (let i=0; i<pil.polIdentities.length; i++) {
+        console.log(`Checking identities ${i+1}/${pil.polIdentities.length}`);
+        await calculateExpression(pil.polIdentities[i].e);
+
+        for (let j=0; j<N; j++) {
+            const v = pols.exps[pil.polIdentities[i].e].v_n[j]
+            if (!F.isZero(v)) {
+                res.push(`${pil.polIdentities[i].fileName}:${pil.polIdentities[i].line}: identity does not match w=${j} val=${F.toString(v)} `);
+                console.log(res[res.length-1]);
+                if (!config.continueOnError) j=N;
+            }
+        }
+
+        delete pols.exps[pil.polIdentities[i].e].v_n;
+    }
+
+
+    return res;
+
+
+
+    function eval(exp) {
+        let a = [];
+        let b = [];
+        let c;
+        let r = [];
+        if (exp.op == "add") {
+            a = eval(exp.values[0]);
+            b = eval(exp.values[1]);
+            r = new Array(a.length);
+            for (let i=0; i<a.length; i++) r[i] = F.add(a[i], b[i]);
+        } else if (exp.op == "sub") {
+            a = eval(exp.values[0]);
+            b = eval(exp.values[1]);
+            r = new Array(a.length);
+            for (let i=0; i<a.length; i++) r[i] = F.sub(a[i], b[i]);
+        } else if (exp.op == "mul") {
+            a = eval(exp.values[0]);
+            b = eval(exp.values[1]);
+            r = new Array(a.length);
+            for (let i=0; i<a.length; i++) r[i] = F.mul(a[i], b[i]);
+        } else if (exp.op == "addc") {
+            a = eval(exp.values[0]);
+            c = F.e(exp.const);
+            r = new Array(a.length);
+            for (let i=0; i<a.length; i++) r[i] = F.add(a[i], c);
+        } else if (exp.op == "mulc") {
+            a = eval(exp.values[0]);
+            c = F.e(exp.const);
+            r = new Array(a.length);
+            for (let i=0; i<a.length; i++) r[i] = F.mul(a[i], c);
+        } else if (exp.op == "neg") {
+            a = eval(exp.values[0]);
+            r = new Array(a.length);
+            for (let i=0; i<a.length; i++) r[i] = F.neg(a[i]);
+        } else if (exp.op == "cm") {
+            r = pols.cm[exp.id].v_n;
+            if (exp.next) r = getPrime(r);
+        } else if (exp.op == "const") {
+            r = pols.const[exp.id].v_n;
+            if (exp.next) r = getPrime(r);
+        } else if (exp.op == "exp") {
+            r = pols.exps[exp.id].v_n;
+            if (exp.next) r = getPrime(r);
+        } else if (exp.op == "number") {
+            v = F.e(exp.value);
+            r = new Array(N);
+            for (let i=0; i<N; i++) r[i] = v;
+        } else if (exp.op == "public") {
+            r = new Array(N);
+            for (let i=0; i<N; i++) r[i] = pols.publics[exp.id];
+        } else {
+            throw new Error(`Invalid op: ${exp.op}`);
+        }
+
+        return r;
+    }
+
+
+    function getPrime(p) {
+        const r = p.slice(1);
+        r[p.length-1] = p[0];
+        return r;
+    }
+
+
+    async function calculateExpression(expId) {
+        console.log("calculateExpression: "+ expId);
+
+        if ((pols.exps[expId])&&(pols.exps[expId].v_n)) return pols.exps[expId].v_n;
+
+        await calculateDependencies(pil.expressions[expId]);
+
+        const p = eval(pil.expressions[expId]);
+
+        pols.exps[expId].v_n = p;
+        return pols.exps[expId].v_n;
+    }
+
+    async function calculateDependencies(exp) {
+        if (exp.op == "exp") {
+            await calculateExpression(exp.id);
+        }
+        if (exp.values) {
+            for (let i=0; i<exp.values.length; i++) {
+                await calculateDependencies(exp.values[i]);
+            }
+        }
+    }
+}
+
+
+const cacheConnectionMaps = {};
+
+function getConnectionMap(F, N, nk) {
+    const kc = F.p.toString()+ "_" + N.toString() + "_" + nk.toString();
+    if (cacheConnectionMaps[kc]) return cacheConnectionMaps[kc];
+
+    const pow = log2(N);
+
+    const m = new Array(1<<16);
+    const ks = [1n, ...getKs(F, nk-1)];
+    let w = F.one;
+    const roots = getRoots(F);
+    const wi = roots[pow];
+    for (let i=0; i<N; i++ ) {
+        if ((i%10000) == 0) console.log(`Building cm.. ${i}/${N}`);
+        for (j=0; j<ks.length; j++) {
+            const a = F.mul(ks[j], w);
+            const a1 = Number(a >> 52n);
+            const a2 = Number((a >> 40n)&0xFFFn );
+            const a3 = Number(a&0xFFFFFFFFFFn );
+            if (!m[a1]) m[a1] = new Array(1<<16);
+            if (!m[a1][a2]) m[a1][a2] = {};
+            m[a1][a2][a3] = [j, i];
+        }
+        w = F.mul(w, wi);
+    }
+
+    cacheConnectionMaps[kc] = m;
+    return m;
+}

--- a/tools/pil_verifier.js
+++ b/tools/pil_verifier.js
@@ -1,275 +1,318 @@
 const { log2, getKs, getRoots } = require("./utils.js");
 
 module.exports = async function verifyPil(F, pil, wtnsCols, fixCols, config = {}) {
-
     const res = [];
 
     const refWtns = {};
     const refFix = {};
+    const refPer = {};
     const refIm = {};
-    for (let k of Object.keys(pil.references)) {
-        const r  = pil.references[k];
-        r.name = k;
-        if (r.type == "cmP") {
-            refWtns[r.id] =r;
-        } else if (r.type == "constP") {
-            refFix[r.id] = r;
-        } else if (r.type == "imP") {
-            refIm[r.id] = r;
+    for (let symbol of pil.symbols) {
+        const type = numberToString(symbol.type);
+        if (type == "WITNESS_COL") {
+            refWtns[symbol.id] = symbol;
+        } else if (type == "FIXED_COL") {
+            refFix[symbol.id] = symbol;
+        } else if (type == "PERIODIC_COL") {
+            refPer[symbol.id] = symbol;
+        } else if (type == "IM_COL") {
+            refIm[symbol.id] = symbol;
         } else {
-            throw new Error("Reference type not handled: " + r.type);
+            throw new Error("Reference type not handled: " + type);
         }
     }
 
-    const pols = {
-        cm: [],
-        exps:[],
+    const cols = {
+        wtns: [],
+        exps: [],
         const: [],
-        publics: []
+        publics: [],
     };
 
     const N = wtnsCols.$$n;
 
-    for (let i=0; i<pil.nCommitments; i++) pols.cm[i] = {};
-    for (let i=0; i<pil.expressions.length; i++) pols.exps[i] = {};
-    for (let i=0; i<pil.nConstants; i++) pols.const[i] = {};
+    for (let i = 0; i < pil.nCommitments; i++) cols.wtns[i] = {};
+    for (let i = 0; i < pil.expressions.length; i++) cols.exps[i] = {};
+    for (let i = 0; i < pil.nConstants; i++) cols.const[i] = {};
 
-// 1.- Prepare commited polynomials.
-    for (let i=0; i<wtnsCols.$$nPols; i++) {
-        pols.cm[i].v_n = wtnsCols.$$array[i];
+    // 1.- Prepare commited polynomials.
+    for (let i = 0; i < wtnsCols.$$nCols; i++) {
+        cols.wtns[i].v_n = wtnsCols.$$array[i];
     }
 
-    for (let i=0; i<fixCols.$$nPols; i++) {
-        pols.const[i].v_n = fixCols.$$array[i];
+    // 2.- Prepare fixed polynomials.
+    for (let i = 0; i < fixCols.$$nCols; i++) {
+        cols.const[i].v_n = fixCols.$$array[i];
     }
 
-    for (let i=0; i<pil.publics.length; i++) {
-
+    // 3.- Prepare public inputs.
+    for (let i = 0; i < pil.publics.length; i++) {
         if (config.publics) {
-            pols.publics[i] = BigInt(config.publics[i]);
-            console.log(`loading public[${i+1}/${pil.publics.length}] = ${pols.publics[i]}`);
+            cols.publics[i] = BigInt(config.publics[i]);
+            console.log(
+                `loading public[${i + 1}/${pil.publics.length}] = ${
+                    cols.publics[i]
+                }`
+            );
         } else {
-            console.log(`preparing public ${i+1}/${pil.publics.length}`);
-            if (pil.publics[i].polType == "cmP") {
-                pols.publics[i] = pols.cm[pil.publics[i].polId].v_n[pil.publics[i].idx];
+            console.log(`preparing public ${i + 1}/${pil.publics.length}`);
+            if (pil.publics[i].polType == "WITNESS") {
+                cols.publics[i] =
+                    cols.wtns[pil.publics[i].polId].v_n[pil.publics[i].idx];
             } else if (pil.publics[i].polType == "imP") {
-                await calculateExpression(pil.publics[i].polId);
-                pols.publics[i] = pols.exps[pil.publics[i].polId].v_n[pil.publics[i].idx];
-                delete pols.exps[pil.publics[i].polId].v_n;
+                await computeExpression(pil.publics[i].polId);
+                cols.publics[i] =
+                    cols.exps[pil.publics[i].polId].v_n[pil.publics[i].idx];
+                delete cols.exps[pil.publics[i].polId].v_n;
             } else {
                 throw new Error(`Invalid public type: ${polType.type}`);
             }
         }
     }
 
-    for (let i=0; i<pil.connectionIdentities.length; i++) {
-        console.log(`Checking connectionIdentities ${i+1}/${pil.connectionIdentities.length}`);
-        ci = pil.connectionIdentities[i];
-        for (let j=0; j<ci.pols.length; j++) {
-            await calculateExpression(ci.pols[j]);
-        }
-        for (let j=0; j<ci.connections.length; j++) {
-            await calculateExpression(ci.connections[j]);
-        }
+    // 4.- Check standard identities.
+    for (let i = 0; i < pil.polIdentities.length; i++) {
+        console.log(`Checking identity ${i + 1}/${pil.polIdentities.length}`);
+        await computeExpression(pil.polIdentities[i].e);
 
-        console.log("start generating cm");
-        let cm = getConnectionMap(F, N, ci.pols.length);
-
-        for (let j=0; j<ci.pols.length; j++) {
-            for (let k=0; k<N; k++) {
-                if (k%10000 == 0) console.log(`${k+1}/${N}`);
-                const v1 = pols.exps[ci.pols[j]].v_n[k];
-
-                const a = pols.exps[ci.connections[j]].v_n[k]
-                const a1 = Number(a >> 52n);
-                const a2 = Number((a >> 40n)&0xFFFn );
-                const a3 = Number(a&0xFFFFFFFFFFn );
-
-
-                const [cp, cw] = cm[a1][a2][a3];
-                if (typeof cp == "undefined") {
-                    res.push(`${ci.fileName}:${pil.connectionIdentities[i].line}: invalid copy value w=${j},${k} val=${F.toString(v1)} `);
-                    console.log(res[res.length-1]);
-                }
-                const v2 = pols.exps[ci.pols[cp]].v_n[cw];
-
-                if (!F.eq(v1, v2)) {
-                    res.push(`${ci.fileName}:${pil.connectionIdentities[i].line}: connection does not match p1=${j} w1=${k} p2=${cp}, w2=${cw} val= ${F.toString(v1)} != ${F.toString(v2)}`);
-                    console.log(res[res.length-1]);
-                    k=N;
-                    j=ci.pols.length;
-                }
-            }
-        }
-
-        for (let j=0; j<ci.pols.length; j++) {
-            delete pols.exps[ci.pols[j]].v_n;
-        }
-        for (let j=0; j<ci.connections.length; j++) {
-            delete pols.exps[ci.connections[j]].v_n;
-        }
-
-    }
-
-    for (let i=0; i<pil.plookupIdentities.length; i++) {
-        console.log(`Checking plookupIdentities ${i+1}/${pil.plookupIdentities.length}`);
-        const pi =pil.plookupIdentities[i];
-
-        for (let j=0; j<pi.t.length; j++) {
-            await calculateExpression(pi.t[j]);
-        }
-        if (pi.selT !== null) {
-            await calculateExpression(pi.selT);
-        }
-        for (let j=0; j<pi.f.length; j++) {
-            await calculateExpression(pi.f[j]);
-        }
-        if (pi.selF !== null) {
-            await calculateExpression(pi.selF);
-        }
-
-        let t = {};
-        for (let j=0; j<N; j++) {
-            const selTValue = pi.selT == null ? F.one : pols.exps[pi.selT].v_n[j];
-            if (!F.isZero(selTValue)) {
-                const vals = []
-                for (let k=0; k<pi.t.length; k++) {
-                    vals.push(F.toString(pols.exps[pi.t[k]].v_n[j]));
-                }
-                const v = selTValue + ':' + vals.join(",");
-                t[v] = true;
-            }
-        }
-
-        for (let j=0; j<N; j++) {
-            const selFValue = pi.selF == null ? F.one : pols.exps[pi.selF].v_n[j];
-            if (!F.isZero(selFValue)) {
-                const vals = []
-                for (let k=0; k<pi.f.length; k++) {
-                    vals.push(F.toString(pols.exps[pi.f[k]].v_n[j]));
-                }
-                const v = selFValue + ':' + vals.join(",");
-                if (!t[v]) {
-                    res.push(`${pil.plookupIdentities[i].fileName}:${pil.plookupIdentities[i].line}:  plookup not found w=${j} values: ${v}`);
-                    console.log(res[res.length-1]);
-                    if (!config.continueOnError) j=N;  // Do not continue checking
-                }
-            }
-        }
-
-        for (let j=0; j<pi.t.length; j++) {
-            delete pols.exps[pi.t[j]].v_n;
-        }
-        if (pi.selT !== null) {
-            delete pols.exps[pi.selT].v_n;
-        }
-        for (let j=0; j<pi.f.length; j++) {
-            delete pols.exps[pi.f[j]].v_n;
-        }
-        if (pi.selF !== null) {
-            delete pols.exps[pi.selF].v_n;
-        }
-
-    }
-
-
-    for (let i=0; i<pil.permutationIdentities.length; i++) {
-        console.log(`Checking permutationIdentities ${i+1}/${pil.permutationIdentities.length}`);
-
-        const pi =pil.permutationIdentities[i];
-
-        for (let j=0; j<pi.t.length; j++) {
-            await calculateExpression(pi.t[j]);
-        }
-        if (pi.selT !== null) {
-            await calculateExpression(pi.selT);
-        }
-        for (let j=0; j<pi.f.length; j++) {
-            await calculateExpression(pi.f[j]);
-        }
-        if (pi.selF !== null) {
-            await calculateExpression(pi.selF);
-        }
-
-        let t = {};
-        for (let j=0; j<N; j++) {
-            const selTValue = pi.selT == null ? F.one : pols.exps[pi.selT].v_n[j];
-            if (!F.isZero(selTValue)) {
-                const vals = []
-                for (let k=0; k<pi.t.length; k++) {
-                    vals.push(F.toString(pols.exps[pi.t[k]].v_n[j]));
-                }
-                const v = selTValue + ':' + vals.join(",");
-                t[v] = (t[v] || 0) + 1;
-            }
-        }
-
-        let showRemainingErrors = true;
-        for (let j=0; j<N; j++) {
-            const selFValue = pi.selF == null ? F.one : pols.exps[pi.selF].v_n[j];
-            if (!F.isZero(selFValue)) {
-                const vals = []
-                for (let k=0; k<pi.f.length; k++) {
-                    vals.push(F.toString(pols.exps[pi.f[k]].v_n[j]));
-                }
-                const v = selFValue + ':' + vals.join(",");
-                const found = t[v] ?? false;
-                if (!t[v]) {
-                    res.push(`${pi.fileName}:${pi.line}:  permutation not `+(found === 0 ? 'enought ':'')+`found w=${j} values: ${v}`);
-                    console.log(res[res.length-1]);
-                    if (!config.continueOnError) {
-                        j=N;  // Do not continue checking
-                        showRemainingErrors = false;
-                    }
-                }
-                else {
-                    t[v] -= 1;
-                }
-            }
-        }
-        if (showRemainingErrors) {
-            for (const v in t) {
-                if (t[v] === 0) continue;
-                res.push(`${pi.fileName}:${pi.line}:  permutation failed. Remaining ${t[v]} values: ${v}`);
-                console.log(res[res.length-1]);
-            }
-        }
-
-        for (let j=0; j<pi.t.length; j++) {
-            delete pols.exps[pi.t[j]].v_n;
-        }
-        if (pi.selT !== null) {
-            delete pols.exps[pi.selT].v_n;
-        }
-        for (let j=0; j<pi.f.length; j++) {
-            delete pols.exps[pi.f[j]].v_n;
-        }
-        if (pi.selF !== null) {
-            delete pols.exps[pi.selF].v_n;
-        }
-
-    }
-
-    for (let i=0; i<pil.polIdentities.length; i++) {
-        console.log(`Checking identities ${i+1}/${pil.polIdentities.length}`);
-        await calculateExpression(pil.polIdentities[i].e);
-
-        for (let j=0; j<N; j++) {
-            const v = pols.exps[pil.polIdentities[i].e].v_n[j]
+        for (let j = 0; j < N; j++) {
+            const v = cols.exps[pil.polIdentities[i].e].v_n[j];
             if (!F.isZero(v)) {
-                res.push(`${pil.polIdentities[i].fileName}:${pil.polIdentities[i].line}: identity does not match w=${j} val=${F.toString(v)} `);
-                console.log(res[res.length-1]);
-                if (!config.continueOnError) j=N;
+                res.push(
+                    `${pil.polIdentities[i].fileName}:${
+                        pil.polIdentities[i].line
+                    }: identity does not match w=${j} val=${F.toString(v)} `
+                );
+                console.log(res[res.length - 1]);
+                if (!config.continueOnError) j = N;
             }
         }
 
-        delete pols.exps[pil.polIdentities[i].e].v_n;
+        delete cols.exps[pil.polIdentities[i].e].v_n;
     }
 
+    // // 5.- Check connection identities.
+    // for (let i = 0; i < pil.connectionIdentities.length; i++) {
+    //     console.log(
+    //         `Checking connectionIdentities ${i + 1}/${
+    //             pil.connectionIdentities.length
+    //         }`
+    //     );
+    //     ci = pil.connectionIdentities[i];
+    //     for (let j = 0; j < ci.cols.length; j++) {
+    //         await computeExpression(ci.cols[j]);
+    //     }
+    //     for (let j = 0; j < ci.connections.length; j++) {
+    //         await computeExpression(ci.connections[j]);
+    //     }
+
+    //     console.log("start generating wtns");
+    //     let wtns = getConnectionMap(F, N, ci.cols.length);
+
+    //     for (let j = 0; j < ci.cols.length; j++) {
+    //         for (let k = 0; k < N; k++) {
+    //             if (k % 10000 == 0) console.log(`${k + 1}/${N}`);
+    //             const v1 = cols.exps[ci.cols[j]].v_n[k];
+
+    //             const a = cols.exps[ci.connections[j]].v_n[k];
+    //             const a1 = Number(a >> 52n);
+    //             const a2 = Number((a >> 40n) & 0xfffn);
+    //             const a3 = Number(a & 0xffffffffffn);
+
+    //             const [cp, cw] = wtns[a1][a2][a3];
+    //             if (typeof cp == "undefined") {
+    //                 res.push(
+    //                     `${ci.fileName}:${
+    //                         pil.connectionIdentities[i].line
+    //                     }: invalid copy value w=${j},${k} val=${F.toString(
+    //                         v1
+    //                     )} `
+    //                 );
+    //                 console.log(res[res.length - 1]);
+    //             }
+    //             const v2 = cols.exps[ci.cols[cp]].v_n[cw];
+
+    //             if (!F.eq(v1, v2)) {
+    //                 res.push(
+    //                     `${ci.fileName}:${
+    //                         pil.connectionIdentities[i].line
+    //                     }: connection does not match p1=${j} w1=${k} p2=${cp}, w2=${cw} val= ${F.toString(
+    //                         v1
+    //                     )} != ${F.toString(v2)}`
+    //                 );
+    //                 console.log(res[res.length - 1]);
+    //                 k = N;
+    //                 j = ci.cols.length;
+    //             }
+    //         }
+    //     }
+
+    //     for (let j = 0; j < ci.cols.length; j++) {
+    //         delete cols.exps[ci.cols[j]].v_n;
+    //     }
+    //     for (let j = 0; j < ci.connections.length; j++) {
+    //         delete cols.exps[ci.connections[j]].v_n;
+    //     }
+    // }
+
+    // // 6.- Check lookup identities.
+    // for (let i = 0; i < pil.plookupIdentities.length; i++) {
+    //     console.log(
+    //         `Checking plookupIdentities ${i + 1}/${
+    //             pil.plookupIdentities.length
+    //         }`
+    //     );
+    //     const pi = pil.plookupIdentities[i];
+
+    //     for (let j = 0; j < pi.t.length; j++) {
+    //         await computeExpression(pi.t[j]);
+    //     }
+    //     if (pi.selT !== null) {
+    //         await computeExpression(pi.selT);
+    //     }
+    //     for (let j = 0; j < pi.f.length; j++) {
+    //         await computeExpression(pi.f[j]);
+    //     }
+    //     if (pi.selF !== null) {
+    //         await computeExpression(pi.selF);
+    //     }
+
+    //     let t = {};
+    //     for (let j = 0; j < N; j++) {
+    //         const selTValue =
+    //             pi.selT == null ? F.one : cols.exps[pi.selT].v_n[j];
+    //         if (!F.isZero(selTValue)) {
+    //             const vals = [];
+    //             for (let k = 0; k < pi.t.length; k++) {
+    //                 vals.push(F.toString(cols.exps[pi.t[k]].v_n[j]));
+    //             }
+    //             const v = selTValue + ":" + vals.join(",");
+    //             t[v] = true;
+    //         }
+    //     }
+
+    //     for (let j = 0; j < N; j++) {
+    //         const selFValue =
+    //             pi.selF == null ? F.one : cols.exps[pi.selF].v_n[j];
+    //         if (!F.isZero(selFValue)) {
+    //             const vals = [];
+    //             for (let k = 0; k < pi.f.length; k++) {
+    //                 vals.push(F.toString(cols.exps[pi.f[k]].v_n[j]));
+    //             }
+    //             const v = selFValue + ":" + vals.join(",");
+    //             if (!t[v]) {
+    //                 res.push(
+    //                     `${pil.plookupIdentities[i].fileName}:${pil.plookupIdentities[i].line}:  plookup not found w=${j} values: ${v}`
+    //                 );
+    //                 console.log(res[res.length - 1]);
+    //                 if (!config.continueOnError) j = N; // Do not continue checking
+    //             }
+    //         }
+    //     }
+
+    //     for (let j = 0; j < pi.t.length; j++) {
+    //         delete cols.exps[pi.t[j]].v_n;
+    //     }
+    //     if (pi.selT !== null) {
+    //         delete cols.exps[pi.selT].v_n;
+    //     }
+    //     for (let j = 0; j < pi.f.length; j++) {
+    //         delete cols.exps[pi.f[j]].v_n;
+    //     }
+    //     if (pi.selF !== null) {
+    //         delete cols.exps[pi.selF].v_n;
+    //     }
+    // }
+
+    // // 7.- Check permutation identities.
+    // for (let i = 0; i < pil.permutationIdentities.length; i++) {
+    //     console.log(
+    //         `Checking permutationIdentities ${i + 1}/${
+    //             pil.permutationIdentities.length
+    //         }`
+    //     );
+
+    //     const pi = pil.permutationIdentities[i];
+
+    //     for (let j = 0; j < pi.t.length; j++) {
+    //         await computeExpression(pi.t[j]);
+    //     }
+    //     if (pi.selT !== null) {
+    //         await computeExpression(pi.selT);
+    //     }
+    //     for (let j = 0; j < pi.f.length; j++) {
+    //         await computeExpression(pi.f[j]);
+    //     }
+    //     if (pi.selF !== null) {
+    //         await computeExpression(pi.selF);
+    //     }
+
+    //     let t = {};
+    //     for (let j = 0; j < N; j++) {
+    //         const selTValue =
+    //             pi.selT == null ? F.one : cols.exps[pi.selT].v_n[j];
+    //         if (!F.isZero(selTValue)) {
+    //             const vals = [];
+    //             for (let k = 0; k < pi.t.length; k++) {
+    //                 vals.push(F.toString(cols.exps[pi.t[k]].v_n[j]));
+    //             }
+    //             const v = selTValue + ":" + vals.join(",");
+    //             t[v] = (t[v] || 0) + 1;
+    //         }
+    //     }
+
+    //     let showRemainingErrors = true;
+    //     for (let j = 0; j < N; j++) {
+    //         const selFValue =
+    //             pi.selF == null ? F.one : cols.exps[pi.selF].v_n[j];
+    //         if (!F.isZero(selFValue)) {
+    //             const vals = [];
+    //             for (let k = 0; k < pi.f.length; k++) {
+    //                 vals.push(F.toString(cols.exps[pi.f[k]].v_n[j]));
+    //             }
+    //             const v = selFValue + ":" + vals.join(",");
+    //             const found = t[v] ?? false;
+    //             if (!t[v]) {
+    //                 res.push(
+    //                     `${pi.fileName}:${pi.line}:  permutation not ` +
+    //                         (found === 0 ? "enought " : "") +
+    //                         `found w=${j} values: ${v}`
+    //                 );
+    //                 console.log(res[res.length - 1]);
+    //                 if (!config.continueOnError) {
+    //                     j = N; // Do not continue checking
+    //                     showRemainingErrors = false;
+    //                 }
+    //             } else {
+    //                 t[v] -= 1;
+    //             }
+    //         }
+    //     }
+    //     if (showRemainingErrors) {
+    //         for (const v in t) {
+    //             if (t[v] === 0) continue;
+    //             res.push(
+    //                 `${pi.fileName}:${pi.line}:  permutation failed. Remaining ${t[v]} values: ${v}`
+    //             );
+    //             console.log(res[res.length - 1]);
+    //         }
+    //     }
+
+    //     for (let j = 0; j < pi.t.length; j++) {
+    //         delete cols.exps[pi.t[j]].v_n;
+    //     }
+    //     if (pi.selT !== null) {
+    //         delete cols.exps[pi.selT].v_n;
+    //     }
+    //     for (let j = 0; j < pi.f.length; j++) {
+    //         delete cols.exps[pi.f[j]].v_n;
+    //     }
+    //     if (pi.selF !== null) {
+    //         delete cols.exps[pi.selF].v_n;
+    //     }
+    // }
 
     return res;
-
-
 
     function eval(exp) {
         let a = [];
@@ -280,47 +323,47 @@ module.exports = async function verifyPil(F, pil, wtnsCols, fixCols, config = {}
             a = eval(exp.values[0]);
             b = eval(exp.values[1]);
             r = new Array(a.length);
-            for (let i=0; i<a.length; i++) r[i] = F.add(a[i], b[i]);
+            for (let i = 0; i < a.length; i++) r[i] = F.add(a[i], b[i]);
         } else if (exp.op == "sub") {
             a = eval(exp.values[0]);
             b = eval(exp.values[1]);
             r = new Array(a.length);
-            for (let i=0; i<a.length; i++) r[i] = F.sub(a[i], b[i]);
+            for (let i = 0; i < a.length; i++) r[i] = F.sub(a[i], b[i]);
         } else if (exp.op == "mul") {
             a = eval(exp.values[0]);
             b = eval(exp.values[1]);
             r = new Array(a.length);
-            for (let i=0; i<a.length; i++) r[i] = F.mul(a[i], b[i]);
+            for (let i = 0; i < a.length; i++) r[i] = F.mul(a[i], b[i]);
         } else if (exp.op == "addc") {
             a = eval(exp.values[0]);
             c = F.e(exp.const);
             r = new Array(a.length);
-            for (let i=0; i<a.length; i++) r[i] = F.add(a[i], c);
+            for (let i = 0; i < a.length; i++) r[i] = F.add(a[i], c);
         } else if (exp.op == "mulc") {
             a = eval(exp.values[0]);
             c = F.e(exp.const);
             r = new Array(a.length);
-            for (let i=0; i<a.length; i++) r[i] = F.mul(a[i], c);
+            for (let i = 0; i < a.length; i++) r[i] = F.mul(a[i], c);
         } else if (exp.op == "neg") {
             a = eval(exp.values[0]);
             r = new Array(a.length);
-            for (let i=0; i<a.length; i++) r[i] = F.neg(a[i]);
-        } else if (exp.op == "cm") {
-            r = pols.cm[exp.id].v_n;
+            for (let i = 0; i < a.length; i++) r[i] = F.neg(a[i]);
+        } else if (exp.op == "wtns") {
+            r = cols.wtns[exp.id].v_n;
             if (exp.next) r = getPrime(r);
         } else if (exp.op == "const") {
-            r = pols.const[exp.id].v_n;
+            r = cols.const[exp.id].v_n;
             if (exp.next) r = getPrime(r);
         } else if (exp.op == "exp") {
-            r = pols.exps[exp.id].v_n;
+            r = cols.exps[exp.id].v_n;
             if (exp.next) r = getPrime(r);
         } else if (exp.op == "number") {
             v = F.e(exp.value);
             r = new Array(N);
-            for (let i=0; i<N; i++) r[i] = v;
+            for (let i = 0; i < N; i++) r[i] = v;
         } else if (exp.op == "public") {
             r = new Array(N);
-            for (let i=0; i<N; i++) r[i] = pols.publics[exp.id];
+            for (let i = 0; i < N; i++) r[i] = cols.publics[exp.id];
         } else {
             throw new Error(`Invalid op: ${exp.op}`);
         }
@@ -328,61 +371,59 @@ module.exports = async function verifyPil(F, pil, wtnsCols, fixCols, config = {}
         return r;
     }
 
-
     function getPrime(p) {
         const r = p.slice(1);
-        r[p.length-1] = p[0];
+        r[p.length - 1] = p[0];
         return r;
     }
 
+    async function computeExpression(expId) {
+        console.log("Computing expression: " + expId);
 
-    async function calculateExpression(expId) {
-        console.log("calculateExpression: "+ expId);
-
-        if ((pols.exps[expId])&&(pols.exps[expId].v_n)) return pols.exps[expId].v_n;
+        if (cols.exps[expId] && cols.exps[expId].v_n)
+            return cols.exps[expId].v_n;
 
         await calculateDependencies(pil.expressions[expId]);
 
         const p = eval(pil.expressions[expId]);
 
-        pols.exps[expId].v_n = p;
-        return pols.exps[expId].v_n;
+        cols.exps[expId].v_n = p;
+        return cols.exps[expId].v_n;
     }
 
     async function calculateDependencies(exp) {
         if (exp.op == "exp") {
-            await calculateExpression(exp.id);
+            await computeExpression(exp.id);
         }
         if (exp.values) {
-            for (let i=0; i<exp.values.length; i++) {
+            for (let i = 0; i < exp.values.length; i++) {
                 await calculateDependencies(exp.values[i]);
             }
         }
     }
-}
-
+};
 
 const cacheConnectionMaps = {};
 
 function getConnectionMap(F, N, nk) {
-    const kc = F.p.toString()+ "_" + N.toString() + "_" + nk.toString();
+    const kc = F.p.toString() + "_" + N.toString() + "_" + nk.toString();
     if (cacheConnectionMaps[kc]) return cacheConnectionMaps[kc];
 
     const pow = log2(N);
 
-    const m = new Array(1<<16);
-    const ks = [1n, ...getKs(F, nk-1)];
+    const m = new Array(1 << 16);
+    const ks = [1n, ...getKs(F, nk - 1)];
     let w = F.one;
     const roots = getRoots(F);
     const wi = roots[pow];
-    for (let i=0; i<N; i++ ) {
-        if ((i%10000) == 0) console.log(`Building cm.. ${i}/${N}`);
-        for (j=0; j<ks.length; j++) {
+    for (let i = 0; i < N; i++) {
+        if (i % 10000 == 0) console.log(`Building wtns.. ${i}/${N}`);
+        for (j = 0; j < ks.length; j++) {
             const a = F.mul(ks[j], w);
             const a1 = Number(a >> 52n);
-            const a2 = Number((a >> 40n)&0xFFFn );
-            const a3 = Number(a&0xFFFFFFFFFFn );
-            if (!m[a1]) m[a1] = new Array(1<<16);
+            const a2 = Number((a >> 40n) & 0xfffn);
+            const a3 = Number(a & 0xffffffffffn);
+            if (!m[a1]) m[a1] = new Array(1 << 16);
             if (!m[a1][a2]) m[a1][a2] = {};
             m[a1][a2][a3] = [j, i];
         }
@@ -391,4 +432,29 @@ function getConnectionMap(F, N, nk) {
 
     cacheConnectionMaps[kc] = m;
     return m;
+}
+
+function numberToString(number) {
+    switch (number) {
+        case 0:
+            return "IM_COL";
+        case 1:
+            return "FIXED_COL";
+        case 2:
+            return "PERIODIC_COL";
+        case 3:
+            return "WITNESS_COL";
+        case 4:
+            return "PROOF_VALUE";
+        case 5:
+            return "SUBPROOF_VALUE";
+        case 6:
+            return "PUBLIC_VALUE";
+        case 7:
+            return "PUBLIC_TABLE";
+        case 8:
+            return "CHALLENGE";
+        default:
+            throw new Error(`Invalid number ${number}`);
+    }
 }

--- a/tools/pilout2json.js
+++ b/tools/pilout2json.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const protobuf = require('protobufjs');
+const path = require('path');
+const fs = require('fs');
+const version = require('../package').version;
+
+const argv = require('yargs')
+    .version(version)
+    .usage('$0 <source.ptb>')
+    // .alias('o', 'output')
+    // .alias('P', 'config')
+    // .alias('v', 'verbose')
+    .argv;
+
+async function run() {
+    let inputFile;
+    if (argv._.length == 0) {
+        console.log('You need to specify a source file');
+        process.exit(1);
+    } else if (argv._.length == 1) {
+        inputFile = argv._[0];
+    } else {
+        console.log('Only one pilout at a time is permited');
+        process.exit(1);
+    }
+
+    const fullFileName = path.resolve(process.cwd(), inputFile);
+
+    // Decode the pilout from its root
+    const piloutEnc = fs.readFileSync(fullFileName);
+    const path2proto = path.join(__dirname, '..', 'src', '/pilout.proto');
+    const root = protobuf.loadSync(path2proto);
+    const PilOut = root.lookupType('PilOut');
+    const piloutDec = PilOut.toObject(PilOut.decode(piloutEnc));
+    
+    fs.writeFileSync("pilout.json", JSON.stringify(piloutDec, null, 2));
+}
+
+run().then(
+    () => {
+        process.exit(0);
+    },
+    (err) => {
+        console.log(err.stack);
+        if (err.pos) {
+            console.error(
+                `ERROR at ${err.errFile}:${err.pos.first_line},${err.pos.first_column}-${err.pos.last_line},${err.pos.last_column}   ${err.errStr}`
+            );
+        } else {
+            console.log(err.message);
+        }
+        process.exit(1);
+    }
+);

--- a/tools/pilouthr.js
+++ b/tools/pilouthr.js
@@ -3,7 +3,6 @@
 const protobuf = require('protobufjs');
 const path = require('path');
 const fs = require('fs');
-const exp = require('constants');
 const version = require('../package').version;
 
 const argv = require('yargs')


### PR DESCRIPTION
The PIL2 library now fully supports the arguments that were used in PIL1:

1.  Multiset equalities checks: 
  ```
  multiset_require(int opid, expr sel, expr cols[])
  
  multiset_provide(int opid, expr sel, expr cols[])
  ```
2.  Lookup checks: 
  ```
  lookup_require(int opid, expr mul_count, expr cols[])
  
  lookup_provide(int opid, expr mul_count, expr cols[])
  ```
3.  Range checks: 
  ```
  range_check(int opid, expr sels[], expr cols[], int min, int max)
  ```
4.  Connections with two different (but compatible) interfaces:

    -  Interface where the user uses either the update_one_cell() or the update_multiple_cells() method to define the permutation "on the fly" and when it is done, executes the connect() method to perform the connection argument. The user also needs to execute init() at the beginning.
          ```
          connection_init(int opid, expr cols[])

          connection_update_one_cell(int opid, expr cols1[], int rows1[], expr cols2[], int rows2[])
          
          connection_update_multiple_cells(int opid, expr cols[], int rows[][])
          
          connection_connect(int opid) 
          ```

    -  Interface where the user knows both the inputs (placed in require) and the permutation (placed in provide) of the argument.
          ```
          connection_require(int opid, expr cols[])

          connection_provide(int opid, expr cols[])
          ```